### PR TITLE
Refactor/lin 50 user profile qa

### DIFF
--- a/src/app/(profile)/(component)/Activities.tsx
+++ b/src/app/(profile)/(component)/Activities.tsx
@@ -17,10 +17,6 @@ const Activities = async ({ userid }: Props) => {
     <>
       <h2 className='text-mogazoa-18px-600 mt-15 mb-7.5 xl:mt-0'>활동 내역</h2>
       <div className='flex gap-2.5 xl:gap-5'>
-        {/* 
-            지금 이 남긴 별점 평균이 시안이랑 다르게 단어가 끊기는데 
-            이건 폰트 제대로 반영된 후에도 이러면 아예 ReactNode로 넘겨줘서 <br>하고 함께 넘기겠습니다.
-        */}
         <StatisticsCard title='남긴 별점 평균'>
           <div className='text-yellow-ffc83c flex gap-[5px]'>
             <StarIcon size={20} />

--- a/src/app/(profile)/(component)/Activities.tsx
+++ b/src/app/(profile)/(component)/Activities.tsx
@@ -25,7 +25,7 @@ const Activities = async ({ userid }: Props) => {
         </StatisticsCard>
 
         <StatisticsCard title='남긴 리뷰'>
-          <div className='mt-4 flex gap-[5px] md:mt-0'>
+          <div className='flex gap-[5px]'>
             <ReviewIcon size={20} />
             {data.reviewCount}
           </div>
@@ -33,8 +33,8 @@ const Activities = async ({ userid }: Props) => {
 
         <StatisticsCard title='관심 카테고리'>
           <CategoryChip
-            className='text-mogazoa-14px-400 px-3 py-2' //시안과 다르게 카테고리 칩 크기 키우기
-            category={data.mostFavoriteCategory ?? { id: 1, name: '기타' }}
+            className='text-mogazoa-14px-400 md:text-mogazoa-16px-400' //시안과 다르게 카테고리 칩 크기 키우기
+            category={data.mostFavoriteCategory ?? { id: 3, name: '기타' }}
           />
         </StatisticsCard>
       </div>

--- a/src/app/(profile)/(component)/Activities.tsx
+++ b/src/app/(profile)/(component)/Activities.tsx
@@ -33,8 +33,8 @@ const Activities = async ({ userid }: Props) => {
 
         <StatisticsCard title='관심 카테고리'>
           <CategoryChip
-            className='text-mogazoa-14px-400 md:text-mogazoa-16px-400' //시안과 다르게 카테고리 칩 크기 키우기
-            category={data.mostFavoriteCategory ?? { id: 3, name: '기타' }}
+            className='md:text-mogazoa-16px-400 break-words' //시안과 다르게 카테고리 칩 크기 키우기
+            category={data.mostFavoriteCategory ?? { id: 6, name: '기타' }}
           />
         </StatisticsCard>
       </div>

--- a/src/app/(profile)/(component)/FollowInfoList.tsx
+++ b/src/app/(profile)/(component)/FollowInfoList.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 const FollowInfoList = ({ type }: Props) => {
   const loadMoreRef = useRef<HTMLDivElement | null>(null);
-  const close = useModalStore((state) => state.close);
+  const closeModal = useModalStore((state) => state.closeModal);
 
   const { userList, isFetching, fetchFollowInfo, cursor } = useFetchUserList(type);
 
@@ -35,7 +35,7 @@ const FollowInfoList = ({ type }: Props) => {
       {userList?.map(({ id, nickname }: FollowUserInfo) => {
         return (
           <li key={id}>
-            <Link href={`/user/${id}`} className='flex items-center gap-5' onClick={close}>
+            <Link href={`/user/${id}`} className='flex items-center gap-5' onClick={closeModal}>
               {/*추후 이미지로 변경*/}
               <div className='bg-green-05d58b h-12 w-12 rounded-full md:h-13 md:w-13' />
               {nickname}

--- a/src/app/(profile)/(component)/FollowInfoList.tsx
+++ b/src/app/(profile)/(component)/FollowInfoList.tsx
@@ -35,7 +35,7 @@ const FollowInfoList = ({ type }: Props) => {
       {userList?.map(({ id, nickname }: FollowUserInfo) => {
         return (
           <li key={id}>
-            <Link href={`/user/${id}`} onClick={close} className='flex items-center gap-5'>
+            <Link href={`/user/${id}`} className='flex items-center gap-5' onClick={close}>
               {/*추후 이미지로 변경*/}
               <div className='bg-green-05d58b h-12 w-12 rounded-full md:h-13 md:w-13' />
               {nickname}

--- a/src/app/(profile)/(component)/FollowModalTrigger.tsx
+++ b/src/app/(profile)/(component)/FollowModalTrigger.tsx
@@ -11,14 +11,14 @@ interface Props {
 }
 
 const FollowerModalTrigger = ({ followers, followees, username }: Props) => {
-  const open = useModalStore((state) => state.open);
+  const openModal = useModalStore((state) => state.openModal);
 
   const handleFollowerClick = () => {
-    open({ component: FollowModalContent, props: { username, type: 'followers' } });
+    openModal({ component: FollowModalContent, props: { username, type: 'followers' } });
   };
 
   const handleFolloweeClick = () => {
-    open({ component: FollowModalContent, props: { username, type: 'followees' } });
+    openModal({ component: FollowModalContent, props: { username, type: 'followees' } });
   };
 
   return (

--- a/src/app/(profile)/(component)/FollowModalTrigger.tsx
+++ b/src/app/(profile)/(component)/FollowModalTrigger.tsx
@@ -24,14 +24,14 @@ const FollowerModalTrigger = ({ followers, followees, username }: Props) => {
   return (
     <div className='flex items-center'>
       <button
-        onClick={handleFollowerClick}
         className='border-r-gray-6e6e82 border-r-[1px] pr-[50px] text-center md:pr-20 xl:pr-[50px]'
+        onClick={handleFollowerClick}
       >
         <div className={followerCountText}>{followers}</div>
         <span className={followerTextStyle}>팔로워</span>
       </button>
 
-      <button onClick={handleFolloweeClick} className='pl-[50px] text-center md:pl-20 xl:pl-[50px]'>
+      <button className='pl-[50px] text-center md:pl-20 xl:pl-[50px]' onClick={handleFolloweeClick}>
         <div className={followerCountText}>{followees}</div>
         <span className={followerTextStyle}>팔로잉</span>
       </button>

--- a/src/app/(profile)/(component)/FollowTrigger.tsx
+++ b/src/app/(profile)/(component)/FollowTrigger.tsx
@@ -18,7 +18,7 @@ const FollowTrigger = ({ isFollowing }: Props) => {
   };
 
   return isFollowing ? (
-    <Button onClick={handleUnFollowClick} variant='tertiary'>
+    <Button variant='tertiary' onClick={handleUnFollowClick}>
       팔로우 취소
     </Button>
   ) : (

--- a/src/app/(profile)/(component)/ProfileCard.tsx
+++ b/src/app/(profile)/(component)/ProfileCard.tsx
@@ -16,6 +16,7 @@ const ProfileCard = async ({ userid, myPage }: Props) => {
   const data = await getUserInfo(userid);
 
   const truncatedDescription = truncated(data.description, 140);
+  const truncatedNickname = truncated(data.nickname, 10);
 
   return (
     <div className='border-black-353542 bg-black-252530 relative flex w-[335px] flex-col items-center gap-7.5 rounded-[12px] px-5 py-7.5 md:w-[509px] md:px-7.5 xl:h-fit xl:w-[340px] xl:gap-10 xl:px-5 xl:py-10'>
@@ -38,7 +39,7 @@ const ProfileCard = async ({ userid, myPage }: Props) => {
 
       <div className='flex flex-col items-center justify-between gap-2.5 xl:gap-5'>
         <h2 className='text-mogazoa-20px-600 md:text-mogazoa-24px-600 text-white-f1f1f5'>
-          {data.nickname}
+          {truncatedNickname}
         </h2>
         <p className='text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-gray-6e6e82 break-words'>
           {truncatedDescription}
@@ -51,7 +52,7 @@ const ProfileCard = async ({ userid, myPage }: Props) => {
       />
       {myPage ? (
         <UpdateTrigger
-          nickname={data.nickname}
+          nickname={truncatedNickname}
           description={truncatedDescription}
           image={data.image}
         />

--- a/src/app/(profile)/(component)/ProfileCard.tsx
+++ b/src/app/(profile)/(component)/ProfileCard.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 
 import { getUserInfo } from '@/actions/profile/getUserInfo';
+import { truncated } from '@/lib/utils/truncated';
 
 import FollowerModalTrigger from './FollowModalTrigger';
 import FollowTrigger from './FollowTrigger';
@@ -13,6 +14,8 @@ interface Props {
 
 const ProfileCard = async ({ userid, myPage }: Props) => {
   const data = await getUserInfo(userid);
+
+  const truncatedDescription = truncated(data.description, 140);
 
   return (
     <div className='border-black-353542 bg-black-252530 relative flex w-[335px] flex-col items-center gap-7.5 rounded-[12px] px-5 py-7.5 md:w-[509px] md:px-7.5 xl:h-fit xl:w-[340px] xl:gap-10 xl:px-5 xl:py-10'>
@@ -38,7 +41,7 @@ const ProfileCard = async ({ userid, myPage }: Props) => {
           {data.nickname}
         </h2>
         <p className='text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-gray-6e6e82 break-words'>
-          {data.description}
+          {truncatedDescription}
         </p>
       </div>
       <FollowerModalTrigger
@@ -47,7 +50,11 @@ const ProfileCard = async ({ userid, myPage }: Props) => {
         username={data.nickname}
       />
       {myPage ? (
-        <UpdateTrigger nickname={data.nickname} description={data.description} image={data.image} />
+        <UpdateTrigger
+          nickname={data.nickname}
+          description={truncatedDescription}
+          image={data.image}
+        />
       ) : (
         <FollowTrigger isFollowing={data.isFollowing} />
       )}

--- a/src/app/(profile)/(component)/ProfileUpdateForm.tsx
+++ b/src/app/(profile)/(component)/ProfileUpdateForm.tsx
@@ -75,7 +75,7 @@ const ProfileUpdateForm = () => {
         {/* 요구사항엔 300자 시안에는 500자네요... */}
         <Textbox
           placeholder='자신을 소개하세요'
-          maxLength={300}
+          maxLength={100}
           defaultValue={description}
           {...register('description')}
         />

--- a/src/app/(profile)/(component)/ProfileUpdateForm.tsx
+++ b/src/app/(profile)/(component)/ProfileUpdateForm.tsx
@@ -62,22 +62,22 @@ const ProfileUpdateForm = () => {
           name='image'
           control={control}
           render={({ field }) => (
-            <FileInput value={field.value ?? []} onChange={field.onChange} maxFiles={1} />
+            <FileInput maxFiles={1} value={field.value ?? []} onChange={field.onChange} />
           )}
         />
 
         <Input
           placeholder='닉네임을 입력해주세요'
-          {...register('nickname')}
           errorMessage={errors.nickname?.message}
+          {...register('nickname')}
         />
 
         {/* 요구사항엔 300자 시안에는 500자네요... */}
         <Textbox
           placeholder='자신을 소개하세요'
-          {...register('description')}
           maxLength={300}
           defaultValue={description}
+          {...register('description')}
         />
 
         <Button disabled={!isDirty || isLoading} className='my-5'>

--- a/src/app/(profile)/(component)/ProfileUpdateForm.tsx
+++ b/src/app/(profile)/(component)/ProfileUpdateForm.tsx
@@ -75,7 +75,7 @@ const ProfileUpdateForm = () => {
         {/* 요구사항엔 300자 시안에는 500자네요... */}
         <Textbox
           placeholder='자신을 소개하세요'
-          maxLength={100}
+          maxLength={140}
           defaultValue={description}
           {...register('description')}
         />

--- a/src/app/(profile)/(component)/ProfileUpdateForm.tsx
+++ b/src/app/(profile)/(component)/ProfileUpdateForm.tsx
@@ -17,7 +17,7 @@ import { profileSchema, type ProfileFormValues } from '@/types/profile/profileUp
 
 const ProfileUpdateForm = () => {
   const { showBoundary } = useErrorBoundary();
-  const close = useModalStore((state) => state.close);
+  const closeModal = useModalStore((state) => state.closeModal);
   const [isLoading, setIsLoading] = useState(false);
 
   const nickname = useUserInfoStore((state) => state.nickname);
@@ -47,7 +47,7 @@ const ProfileUpdateForm = () => {
         description: data.description,
         image: data.image,
       });
-      close();
+      closeModal();
     } catch (err) {
       showBoundary(err);
     } finally {

--- a/src/app/(profile)/(component)/ProfileUpdateForm.tsx
+++ b/src/app/(profile)/(component)/ProfileUpdateForm.tsx
@@ -72,7 +72,6 @@ const ProfileUpdateForm = () => {
           {...register('nickname')}
         />
 
-        {/* 요구사항엔 300자 시안에는 500자네요... */}
         <Textbox
           placeholder='자신을 소개하세요'
           maxLength={140}

--- a/src/app/(profile)/(component)/ProfileUpdateForm.tsx
+++ b/src/app/(profile)/(component)/ProfileUpdateForm.tsx
@@ -31,7 +31,7 @@ const ProfileUpdateForm = () => {
     formState: { errors, isDirty },
   } = useForm<ProfileFormValues>({
     resolver: zodResolver(profileSchema),
-    mode: 'all',
+    mode: 'onBlur',
     defaultValues: {
       nickname,
       description,

--- a/src/app/(profile)/(component)/StatisticsCard.tsx
+++ b/src/app/(profile)/(component)/StatisticsCard.tsx
@@ -7,7 +7,7 @@ interface Props {
 
 const ActivityCard = ({ title, children }: Props) => {
   return (
-    <div className='border-black-353542 bg-black-252530 flex h-[119px] w-[105px] flex-col items-center justify-center gap-[15px] rounded-[12px] px-5 py-5 md:w-[163px] xl:h-[128px] xl:w-[300px] xl:gap-5'>
+    <div className='border-black-353542 bg-black-252530 flex h-[119px] w-[105px] flex-col items-center justify-center gap-[15px] rounded-[12px] md:w-[163px] xl:h-[128px] xl:w-[300px] xl:gap-5'>
       <h3 className='text-mogazoa-14px-500 xl:text-mogazoa-16px-500 text-gray-9fa6b2 text-center break-keep'>
         {title}
       </h3>

--- a/src/app/(profile)/(component)/UpdateTrigger.tsx
+++ b/src/app/(profile)/(component)/UpdateTrigger.tsx
@@ -19,11 +19,11 @@ const UpdateTrigger = ({ nickname, description, image }: Props) => {
 
   setUserInfo({ nickname, description, image });
 
-  const open = useModalStore((state) => state.open);
+  const openModal = useModalStore((state) => state.openModal);
 
   return (
     <div className='w-full'>
-      <Button onClick={() => open({ component: ProfileUpdateModal })}>프로필 편집</Button>
+      <Button onClick={() => openModal({ component: ProfileUpdateModal })}>프로필 편집</Button>
       <Button variant='tertiary' className='mt-2.5 md:mt-[15px] xl:mt-5'>
         로그아웃
       </Button>

--- a/src/app/(profile)/loading.tsx
+++ b/src/app/(profile)/loading.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const LoadingFallback = () => {
-  return <div>로로오오오오딩</div>;
-};
-
-export default LoadingFallback;

--- a/src/app/_components/CategoryModal.tsx
+++ b/src/app/_components/CategoryModal.tsx
@@ -9,7 +9,7 @@ import { CATEGORY_NAME_MAP } from '@/lib/utils/categoryNameMap';
 import { useModalStore } from '@/store/modalStore';
 
 const CategoryModal = () => {
-  const { close } = useModalStore();
+  const { closeModal } = useModalStore();
   const { navigateToCategory } = useCategoryNavigation();
   const searchParams = useSearchParams();
   const selectedCategory = searchParams.get('categoryId')
@@ -18,12 +18,12 @@ const CategoryModal = () => {
 
   const handleCategorySelect = (categoryId: number | null) => {
     navigateToCategory(categoryId);
-    close(); // 선택 후 모달 닫기
+    closeModal(); // 선택 후 모달 닫기
   };
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
-      close();
+      closeModal();
     }
   };
 
@@ -37,7 +37,7 @@ const CategoryModal = () => {
         <div className='mb-6 flex items-center justify-between'>
           <h2 className='text-mogazoa-18px-600 text-white-f1f1f5'>카테고리 선택</h2>
           <button
-            onClick={close}
+            onClick={closeModal}
             className='text-gray-9fa6b2 hover:text-white-f1f1f5 text-xl transition-colors'
           >
             ×

--- a/src/app/_components/MobileCategoryFilter.tsx
+++ b/src/app/_components/MobileCategoryFilter.tsx
@@ -13,7 +13,7 @@ interface MobileCategoryFilterProps {
 }
 
 const MobileCategoryFilter = ({ className }: MobileCategoryFilterProps) => {
-  const { open } = useModalStore();
+  const { openModal } = useModalStore();
   const searchParams = useSearchParams();
   const selectedCategory = searchParams.get('categoryId')
     ? Number(searchParams.get('categoryId'))
@@ -24,7 +24,7 @@ const MobileCategoryFilter = ({ className }: MobileCategoryFilterProps) => {
     : '전체 카테고리';
 
   const handleClick = () => {
-    open({
+    openModal({
       component: CategoryModal,
       props: {},
     });

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -7,12 +7,6 @@
 //이때 FallbackComponent로 오는 ErrorFallback이 쓰이기 때문에 타입이 다르게 들어올 거라고 생각했어요 ->(이 컴포넌트를 종류가 다른 두 에러바운더리에서 사용한다는 말)
 //-> 그래서 아래와 같이 확장하고 reset이 있으면 reset을 쓰고 resetErrorBoundary가 있으면 이걸 쓰는 식으로 짰습니다.
 
-interface Props extends Partial<FallbackProps> {
-  error: Error;
-  reset?: () => void;
-  className?: string;
-}
-
 import React, { startTransition } from 'react';
 
 import { useRouter } from 'next/navigation';
@@ -20,6 +14,15 @@ import { FallbackProps } from 'react-error-boundary';
 
 import Button from '@/components/ui/Buttons';
 import { cn } from '@/lib/utils';
+
+interface Props extends Partial<FallbackProps> {
+  error: Error; //-> 서버액션에서의 에러 발생은 Error타입
+  // //리액트 에러바운더리의 에러발생은 any로 정의되어 있기는 한데 애초에 서버액션에서 throw한 에러가
+  // 서버액션 호출부의 try/catch에서 걸리고 showBoundary를 통해 넘어오니까 무조건 Error타입(throw new Error(에러 생성자로 던져준 거니까)
+  //Error는 js전역 내장 타입이니까 임포트x
+  reset?: () => void;
+  className?: string;
+}
 
 const ErrorFallback = ({ error, reset, resetErrorBoundary }: Props) => {
   const router = useRouter();

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -35,7 +35,7 @@ const ErrorFallback = ({ error, reset, resetErrorBoundary }: Props) => {
         <div className='text-mogazoa-24px-600 mb-10 text-center'>{userErrMsg}</div>
 
         {reset ? (
-          <Button onClick={() => router.back()} className='mb-6'>
+          <Button className='mb-6' onClick={() => router.back()}>
             이전 페이지로 돌아가기
           </Button>
         ) : null}

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -13,7 +13,7 @@ const ErrorFallback = ({}) => {
       <div className={cn('m-auto mt-80 max-w-[640px]')}>
         <div className='text-mogazoa-24px-600 mb-10 text-center'>존재하지 않는 페이지입니다</div>
 
-        <Button onClick={() => router.back()} className='mb-6'>
+        <Button className='mb-6' onClick={() => router.back()}>
           이전 페이지로 돌아가기
         </Button>
       </div>

--- a/src/components/common/FileInput.tsx
+++ b/src/components/common/FileInput.tsx
@@ -51,7 +51,6 @@ const FileInput = ({ maxFiles = 1, value, onChange }: FileInputProps) => {
       {/* 업로드 버튼 */}
       {files.length < maxFiles && (
         <div
-          onClick={() => fileInputRef.current?.click()}
           className={cn(
             'flex cursor-pointer items-center justify-center',
             'border-black-353542 bg-black-252530 border',
@@ -59,6 +58,7 @@ const FileInput = ({ maxFiles = 1, value, onChange }: FileInputProps) => {
             'md:w-[135px]',
             'xl:w-[160px]',
           )}
+          onClick={() => fileInputRef.current?.click()}
         >
           <Image src='/icon/Icon-addfile.svg' alt='파일 추가 아이콘' width={24} height={24} />
         </div>

--- a/src/components/common/FilePreview.tsx
+++ b/src/components/common/FilePreview.tsx
@@ -23,13 +23,13 @@ const FilePreview = ({ url, index, onRemove }: FilePreviewProps) => {
       <Image src={url} alt={`선택된 이미지 ${index + 1}`} fill style={{ objectFit: 'cover' }} />
       <button
         type='button'
-        onClick={() => onRemove(index)}
         className={cn(
           'absolute top-[5px] right-[5px] flex items-center justify-center',
           'h-[26px] w-[26px] rounded-[8px] p-1',
           'bg-black text-white opacity-50',
         )}
         aria-label='파일 삭제'
+        onClick={() => onRemove(index)}
       >
         <X />
       </button>

--- a/src/components/common/ModalUi.tsx
+++ b/src/components/common/ModalUi.tsx
@@ -23,10 +23,10 @@ const contentStyle = {
 };
 
 const Modal = ({ showCloseButton = true, variant = 'basic', className, children }: Props) => {
-  const close = useModalStore((state) => state.close);
+  const closeModal = useModalStore((state) => state.closeModal);
 
   return (
-    <Dialog open={true} onOpenChange={close}>
+    <Dialog open={true} onOpenChange={closeModal}>
       <DialogContent
         className={cn(className, contentStyle[variant])}
         showCloseButton={showCloseButton}

--- a/src/components/common/ModalUi.tsx
+++ b/src/components/common/ModalUi.tsx
@@ -28,8 +28,8 @@ const Modal = ({ showCloseButton = true, variant = 'basic', className, children 
   return (
     <Dialog open={true} onOpenChange={close}>
       <DialogContent
-        showCloseButton={showCloseButton}
         className={cn(className, contentStyle[variant])}
+        showCloseButton={showCloseButton}
       >
         {/*본격적인 모달 컨텐츠*/}
         {children}

--- a/src/components/common/Textbox.tsx
+++ b/src/components/common/Textbox.tsx
@@ -8,6 +8,10 @@ interface TextboxProps extends React.ComponentProps<'textarea'> {
   maxLength?: number;
 }
 
+const truncated = (e: React.ChangeEvent<HTMLTextAreaElement>, maxLength: number) => {
+  return e.target.value.slice(0, maxLength).length;
+};
+
 const Textbox = React.forwardRef<HTMLTextAreaElement, TextboxProps>(
   ({ maxLength = 300, ...props }, ref) => {
     const [count, setCount] = React.useState(props?.defaultValue?.toString().length ?? 0);
@@ -19,7 +23,7 @@ const Textbox = React.forwardRef<HTMLTextAreaElement, TextboxProps>(
           maxLength={maxLength}
           {...props}
           onChange={(e) => {
-            setCount(e.target.value.length);
+            setCount(truncated(e, 300));
             props.onChange?.(e);
           }}
         />

--- a/src/components/common/Textbox.tsx
+++ b/src/components/common/Textbox.tsx
@@ -3,19 +3,11 @@
 import * as React from 'react';
 
 import { Textarea } from '@/components/ui/textarea';
+import { truncated } from '@/lib/utils/truncated';
 
 interface TextboxProps extends React.ComponentProps<'textarea'> {
   maxLength?: number;
 }
-
-const truncated = (e: React.ChangeEvent<HTMLTextAreaElement>, maxLength: number) => {
-  const chars = e.target.value;
-  if (chars.length > maxLength) {
-    e.target.value = chars.slice(0, maxLength);
-  }
-
-  return chars.slice(0, maxLength).length;
-};
 
 const Textbox = React.forwardRef<HTMLTextAreaElement, TextboxProps>(
   ({ maxLength = 300, ...props }, ref) => {
@@ -28,7 +20,10 @@ const Textbox = React.forwardRef<HTMLTextAreaElement, TextboxProps>(
           spellCheck={false}
           {...props}
           onChange={(e) => {
-            setCount(truncated(e, 100));
+            setCount(() => {
+              e.target.value = truncated(e.target.value, 140);
+              return e.target.value.length;
+            });
             props.onChange?.(e);
           }}
         />

--- a/src/components/common/Textbox.tsx
+++ b/src/components/common/Textbox.tsx
@@ -9,7 +9,12 @@ interface TextboxProps extends React.ComponentProps<'textarea'> {
 }
 
 const truncated = (e: React.ChangeEvent<HTMLTextAreaElement>, maxLength: number) => {
-  return e.target.value.slice(0, maxLength).length;
+  const chars = e.target.value;
+  if (chars.length > maxLength) {
+    e.target.value = chars.slice(0, maxLength);
+  }
+
+  return chars.slice(0, maxLength).length;
 };
 
 const Textbox = React.forwardRef<HTMLTextAreaElement, TextboxProps>(
@@ -20,10 +25,10 @@ const Textbox = React.forwardRef<HTMLTextAreaElement, TextboxProps>(
       <div className='relative w-fit'>
         <Textarea
           ref={ref}
-          maxLength={maxLength}
+          spellCheck={false}
           {...props}
           onChange={(e) => {
-            setCount(truncated(e, 300));
+            setCount(truncated(e, 100));
             props.onChange?.(e);
           }}
         />

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -66,7 +66,7 @@ function DialogContent({
             data-slot='dialog-close'
             className={cn(
               'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
-              'absolute top-9 right-9 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden',
+              'absolute top-8 right-9 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden',
               "disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-full",
               'size-6 md:size-9 xl:size-10', //반응형 x버튼 크기 24, 36, 40
             )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -66,7 +66,7 @@ function DialogContent({
             data-slot='dialog-close'
             className={cn(
               'ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground',
-              'absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden',
+              'absolute top-9 right-9 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:outline-hidden',
               "disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-full",
               'size-6 md:size-9 xl:size-10', //반응형 x버튼 크기 24, 36, 40
             )}
@@ -84,7 +84,7 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot='dialog-header'
-      className={cn('mt-10 flex flex-col text-left', className)}
+      className={cn('mt-5 flex flex-col text-left', className)}
       {...props}
     />
   );

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -55,7 +55,7 @@ function DialogContent({
         className={cn(
           'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
           'data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)]',
-          'w-[355px] translate-x-[-50%] translate-y-[-50%] gap-5 rounded-xl border-0 p-5 shadow-lg duration-200 md:w-[590px] md:gap-10 xl:w-[620px]',
+          'w-[355px] translate-x-[-50%] translate-y-[-50%] gap-5 rounded-xl border-0 p-5 shadow-lg duration-300 md:w-[590px] md:gap-10 xl:w-[620px]',
           className,
         )}
         {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ function Textarea({ ...props }: React.ComponentProps<'textarea'>) {
         'relative rounded-[8px] p-[1px]',
         'focus-within:border-transparent focus-within:bg-gradient-to-r',
         'focus-within:bg-main-gradation',
-        'transition-all duration-700',
+        'transition-all duration-300',
         'w-[295px] md:w-[510px] xl:w-[540px]',
       )}
     >

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -34,6 +34,7 @@ function Textarea({ ...props }: React.ComponentProps<'textarea'>) {
             'no-scrollbar w-full resize-none',
             'focus:ring-0 focus:outline-none',
             'w-full',
+            'text-mogazoa-14px-400, md:text-mogazoa-16px-400',
           )}
           {...props}
         />

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -34,7 +34,7 @@ function Textarea({ ...props }: React.ComponentProps<'textarea'>) {
             'no-scrollbar w-full resize-none',
             'focus:ring-0 focus:outline-none',
             'w-full',
-            'text-mogazoa-14px-400, md:text-mogazoa-16px-400',
+            'text-mogazoa-14px-400 xl:text-mogazoa-16px-400',
           )}
           {...props}
         />

--- a/src/lib/utils/truncated.ts
+++ b/src/lib/utils/truncated.ts
@@ -1,0 +1,8 @@
+export const truncated = (chars: string, maxLength: number) => {
+  let truncatedChars = chars;
+  if (truncatedChars.length > maxLength) {
+    truncatedChars = chars.slice(0, maxLength);
+  }
+
+  return truncatedChars;
+};

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -10,14 +10,14 @@ interface Component<P = any> {
 
 type ModalState = {
   stack: Component[];
-  open: (modal: Component) => void;
-  close: () => void;
-  clear: () => void;
+  openModal: (modal: Component) => void;
+  closeModal: () => void;
+  clearModal: () => void;
 };
 
 export const useModalStore = create<ModalState>((set) => ({
   stack: [], //모달을 담아둘 스택
-  open: (modal) => set((state) => ({ stack: [...state.stack, modal] })), //모달 추가
-  close: () => set((state) => ({ stack: state.stack.slice(0, -1) })), //모달 빼기
-  clear: () => set({ stack: [] }), //초기화
+  openModal: (modal) => set((state) => ({ stack: [...state.stack, modal] })), //모달 추가
+  closeModal: () => set((state) => ({ stack: state.stack.slice(0, -1) })), //모달 빼기
+  clearModal: () => set({ stack: [] }), //초기화
 }));

--- a/src/types/profile/profileUpdateSchema.ts
+++ b/src/types/profile/profileUpdateSchema.ts
@@ -5,7 +5,7 @@ export const profileSchema = z.object({
     .string()
     .nonempty('닉네임은 필수 입력입니다.')
     .max(10, '닉네임은 최대 10자까지 가능합니다.'),
-  description: z.string().max(100, '소개는 최대 100자까지 가능해요').optional(),
+  description: z.string().max(140, '소개는 최대 140자까지 가능해요').optional(),
   image: z.array(z.string()).optional(),
 });
 

--- a/src/types/profile/profileUpdateSchema.ts
+++ b/src/types/profile/profileUpdateSchema.ts
@@ -5,7 +5,7 @@ export const profileSchema = z.object({
     .string()
     .nonempty('닉네임은 필수 입력입니다.')
     .max(10, '닉네임은 최대 10자까지 가능합니다.'),
-  description: z.string().max(300, '소개는 최대 300자까지 가능해요').optional(),
+  description: z.string().max(100, '소개는 최대 100자까지 가능해요').optional(),
   image: z.array(z.string()).optional(),
 });
 


### PR DESCRIPTION
멘토님과 함께한 1차 qa 반영입니다.

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/project-part4-team3/issue/LIN-50/%EB%A9%98%ED%86%A0%EB%8B%98-1%EC%B0%A8qa-%EB%B0%98%EC%98%81

## 💡 변경 사항 요약

#### 1.비활성화일땐 커서 블락 
🔍🔍 글로벌 css cursor:pointer 이게 자꾸 마지막에 반영되더라구요
style={{...}} 이런 식으로 인라인으로도 줘봤는데 안 먹혀서
내일 회의때 글로벌 css에 있는 거 지워보고 본인 꺼에 영향 안 가는 확인 후에 지우고 푸시하겠습니다. 

#### 2.액티비티 내부 좌우 패딩 제거
+카테고리 칩 크기 수정

#### 3.모달 닫기버튼 제목 위치 맞추기

#### 4.300자 넘길때 처리 한 글자 튀어나오는 거 수정 + 최대 입력가능 100으로 변경 -> 140으로 수정

#### 5.아이디 클래스네임 핸들러 순으로

#### 6.useForm mode 다른 폼(회원가입)과 동일하게 onBlur로 수정했습니다.

#### 7.모달 스토어 open/close 이름  openModal/ closeModal로 변경했습니다.
@Sophia-parang  빌드 땜에 MobileCategoryFilter/ CategoryModal 이거 안에서 쓰고 있는 이름 변경해 뒀습니다.

#### 8.error.tsx 내부 Error 타입 확인하기 


<회의를 통해 추가>
#### 9.truncated 유틸 함수 추가

#### 10.텍스트박스 모달 트랜지션 듀레이션 300으로 통일

#### 11. 텍스트박스 폰트사이즈 고정 14/14/16




### 📌 세부 변경 내용


#### 2.액티비티 내부 좌우 패딩 제거+ 카테고리 칩 크기 수정

=> 카테고리 칩 자꾸 이리저리 크기 바꿔가면서 보고 있는데요,
그냥 크기 키우고 양옆 패딩 없애는 게 가장 깔끔하게 나오는 것 같습니다.

<img width="988" height="225" alt="image" src="https://github.com/user-attachments/assets/ec80a000-1b7a-4a80-9953-558845f1278e" />

모바일의 경우 첫번째, 세번째 카드가 조금 답답해 보일 수 있는데
카테고리칩 이름 긴 거 걸렸을 때 어떻게 해도 끊기는 부분이 다 이상해서
 작게 한 줄로 들어가게 하고(가장 긴 텍스트 기준) md:부터 크기 확 키웠습니다.

<img width="451" height="178" alt="image" src="https://github.com/user-attachments/assets/7d0fdc1b-e15c-499a-be46-0d7c000e142b" />






#### 3.모달 닫기버튼 제목 위치  맞추기
모달 제목이랑 닫기버튼 위치 맞췄는데 예전이 더 나은 것 같기도 하고 애매한 것 같습니다?
보시고 더 나은 쪽으로 골라주시면 반영해서 푸시하겠습니다.

<바꾼 위치>
<img width="758" height="771" alt="image" src="https://github.com/user-attachments/assets/0a663b0c-61d0-4816-9388-b17facbc5961" />

<이전위치>
<img width="687" height="751" alt="image" src="https://github.com/user-attachments/assets/b3c45aaa-bc8e-482a-a54c-95af98ca87ab" />


#### 4.최대 글자 수 넘길 때  한 글자 튀어나오는 거 수정 
-> 한국어 판정이 조금 이상 => 애초에 최대 글자 수 넘기면 그냥 slice(0,최대 글자수)로 잘라서 e.target.value에 반환 

+ 밑에 빨간 줄 생기는 스펠체크 false옵션 추가

![KakaoTalk_Recording_20250830_025619-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/52a91ca9-60ba-4067-a153-c2cc7fc3b672)


+ 📌📌라인 클램프 써서 너무 길어지면 말줄임표 할 수 있는데
-> 그럼 말줄임표나 자세히 보기 이런 거 클릭해서 전체 소개를 볼 수 있어야 하잖아요?
-> 이러면 결국에 상태로 클라이언트에서 관리하는 구조로 바꿔야 하는데
이걸 바꾸면서까지 꼭 필요한가? 라고 생각해보면 잘 모르겠어요
그래서 그냥 소개 최대치를 100으로 변경했는데 혹시 300자로 하는 게 낫겠다라고 생각하시는 분 계실까요?


#### 5. 제가 작업한 부분들 html태그에 class,variant이런 것들보다 핸들러를 먼저 내려주는 거는 다 뒤로 이동시켰습니다

#### 6.useForm mode 다른 폼(회원가입)과 동일하게 onBlur로 수정했습니다

<img width="323" height="72" alt="image" src="https://github.com/user-attachments/assets/f8ebb9a3-2454-47e4-9349-62fc60a938b2" />

#### 7. 모달 열고 닫기 이름 변경 했습니다
<img width="403" height="131" alt="image" src="https://github.com/user-attachments/assets/fdc13d11-cb66-4642-90e6-56758ffb8f03" />

#### 8. error.tsx 내부 Error 타입 확인하기 
자세한 건 error.tsx파일 안에 주석 달아뒀습니다.
결론은 그냥 Error 맞는 거 같습니다.



### 🧪 테스트 방법 및 결과 (선택 사항)

1.
2.

### 📸 스크린샷 (선택 사항)

### ✍️ 추가 코멘트 (선택 사항)

-
