### PR TITLE
Feat/lin 51 user profile list api

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["followee", "followees", "mogazoa", "pretendard"]
+}

--- a/src/actions/profile/getUserProducts.ts
+++ b/src/actions/profile/getUserProducts.ts
@@ -2,7 +2,7 @@
 
 import fetcher from '@/lib/utils/fetcher';
 
-export const getUserProducts = async (userid: number, option: string = 'created-product') =>
+export const getUserProducts = async (userid: number, option: string = 'reviewed-products') =>
   await fetcher(
     `${process.env.API_BASE_URL}/${process.env.TEST_TEAM_ID}/users/${userid}/${option}`,
     {

--- a/src/actions/profile/getUserProducts.ts
+++ b/src/actions/profile/getUserProducts.ts
@@ -2,14 +2,18 @@
 
 import fetcher from '@/lib/utils/fetcher';
 
-export const getUserProducts = async (userid: number, option: string = 'reviewed-products') =>
+export const getUserProducts = async (
+  userid: number,
+  option: string = 'reviewed-products',
+  cursor: number = 0,
+) =>
   await fetcher(
-    `${process.env.API_BASE_URL}/${process.env.TEST_TEAM_ID}/users/${userid}/${option}`,
+    `${process.env.API_BASE_URL}/${process.env.TEST_TEAM_ID}/users/${userid}/${option}?cursor=${cursor}`,
     {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
       },
-      next: { revalidate: 300, tags: [`${option}`] },
+      cache: 'no-store',
     },
   );

--- a/src/app/(profile)/(component)/Activities.tsx
+++ b/src/app/(profile)/(component)/Activities.tsx
@@ -13,8 +13,7 @@ interface Props {
 const Activities = async ({ userid }: Props) => {
   const data = await getUserInfo(userid);
 
-  const flooraverageRating = Math.floor(data.averageRating);
-  const floorReviewCount = Math.floor(data.reviewCount);
+  const RoundaverageRating = Math.round(data.averageRating * 10) / 10;
 
   return (
     <>
@@ -23,14 +22,14 @@ const Activities = async ({ userid }: Props) => {
         <StatisticsCard title='남긴 별점 평균'>
           <div className='text-yellow-ffc83c flex gap-[5px]'>
             <StarIcon size={20} />
-            <span className='text-white-f1f1f5'>{flooraverageRating}</span>
+            <span className='text-white-f1f1f5'>{RoundaverageRating}</span>
           </div>
         </StatisticsCard>
 
         <StatisticsCard title='남긴 리뷰'>
           <div className='flex gap-[5px]'>
             <ReviewIcon size={20} />
-            {floorReviewCount}
+            {data.reviewCount}
           </div>
         </StatisticsCard>
 

--- a/src/app/(profile)/(component)/Activities.tsx
+++ b/src/app/(profile)/(component)/Activities.tsx
@@ -13,6 +13,9 @@ interface Props {
 const Activities = async ({ userid }: Props) => {
   const data = await getUserInfo(userid);
 
+  const flooraverageRating = Math.floor(data.averageRating);
+  const floorReviewCount = Math.floor(data.reviewCount);
+
   return (
     <>
       <h2 className='text-mogazoa-18px-600 mt-15 mb-7.5 xl:mt-0'>활동 내역</h2>
@@ -20,14 +23,14 @@ const Activities = async ({ userid }: Props) => {
         <StatisticsCard title='남긴 별점 평균'>
           <div className='text-yellow-ffc83c flex gap-[5px]'>
             <StarIcon size={20} />
-            <span className='text-white-f1f1f5'>{data.averageRating}</span>
+            <span className='text-white-f1f1f5'>{flooraverageRating}</span>
           </div>
         </StatisticsCard>
 
         <StatisticsCard title='남긴 리뷰'>
           <div className='flex gap-[5px]'>
             <ReviewIcon size={20} />
-            {data.reviewCount}
+            {floorReviewCount}
           </div>
         </StatisticsCard>
 

--- a/src/app/(profile)/(component)/ProductList.tsx
+++ b/src/app/(profile)/(component)/ProductList.tsx
@@ -1,40 +1,45 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
-import { getUserProducts } from '@/actions/profile/getUserProducts';
 import Empty from '@/assets/icon/Icon-empty.svg';
+import SortDropdown from '@/components/common/dropdowns/SortDropdown';
 import ProductCard from '@/components/common/ProductCard';
+import useFetchUserProductList from '@/hooks/useFetchUserProductList';
+import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
 import { Product } from '@/types/product/productType';
 
 interface Props {
   userid: number;
-  initailData: Product[];
+  initialData: Product[];
 }
 
-const ProductList = ({ userid, initailData }: Props) => {
-  const [movieList, setMovieList] = useState(initailData);
-  const [option, setOption] = useState('created-products');
+const ProductList = ({ userid, initialData }: Props) => {
+  const [option, setOption] = useState('reviewed-products');
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
 
   const onValueChange = (value: string) => {
     setOption(value);
   };
 
-  //드랍다운에 넘겨줄 수 있게 되면 삭제.
-  console.log(onValueChange);
+  const { movieList, isFetching, fetchProducts, cursor } = useFetchUserProductList(
+    userid,
+    option,
+    initialData,
+  );
 
-  const fetchProductsByOption = useCallback(async () => {
-    const data = await getUserProducts(userid, option);
-    setMovieList(data.list);
-  }, [userid, option]);
+  const onIntersect = useCallback(() => {
+    if (!isFetching && cursor !== null) fetchProducts();
+    // eslint-disable-next-line
+  }, [cursor, isFetching]);
 
-  useEffect(() => {
-    fetchProductsByOption();
-  }, [fetchProductsByOption]);
+  useIntersectionObserver(loadMoreRef, cursor, onIntersect);
 
   return (
-    <>
-      <div className='text-mogazoa-18px-600 mt-15 mb-7.5 xl:mt-20'>드랍다운 자리</div>
+    <div className='mb-30 md:mb-15'>
+      <div className='text-mogazoa-18px-600 mt-15 mb-7.5 xl:mt-20'>
+        <SortDropdown variant={'user'} onChange={onValueChange} menuPosition='left' />
+      </div>
       <ul className='flex max-w-[940px] flex-wrap gap-[15px] xl:gap-5'>
         {movieList?.length !== 0 ? (
           movieList?.map((movie) => (
@@ -49,7 +54,7 @@ const ProductList = ({ userid, initailData }: Props) => {
           </div>
         )}
       </ul>
-    </>
+    </div>
   );
 };
 

--- a/src/app/(profile)/(component)/ProductList.tsx
+++ b/src/app/(profile)/(component)/ProductList.tsx
@@ -53,7 +53,7 @@ const ProductList = ({ userid, initialData }: Props) => {
         </div>
         <SortDropdown
           variant={'user'}
-          menuPosition='left'
+          menuPosition='right'
           className='xl:hidden'
           onChange={onValueChange}
         />
@@ -73,7 +73,7 @@ const ProductList = ({ userid, initialData }: Props) => {
             <p className='text-mogazoa-24px-400 mt-6 text-center'>목록이 없습니다</p>
           </div>
         )}
-        {cursor !== null && <div ref={loadMoreRef}>로딩트리거어어어어어ㅓ</div>}
+        {cursor !== null && <div ref={loadMoreRef} className='h-[5px] w-4'></div>}
       </ul>
     </div>
   );

--- a/src/app/(profile)/(component)/ProductList.tsx
+++ b/src/app/(profile)/(component)/ProductList.tsx
@@ -24,7 +24,7 @@ const ProductList = ({ userid, initialData }: Props) => {
     setOption(value);
   };
 
-  const { movieList, isFetching, fetchProducts, cursor, errOccur } = useFetchUserProductList(
+  const { productList, isFetching, fetchProducts, cursor, errOccur } = useFetchUserProductList(
     userid,
     option,
     initialData,
@@ -53,14 +53,15 @@ const ProductList = ({ userid, initialData }: Props) => {
         </div>
         <SortDropdown
           variant={'user'}
-          menuPosition='left'
+          menuPosition='right'
           className='xl:hidden'
           onChange={onValueChange}
+          option={option}
         />
       </div>
       <ul className='flex max-w-[940px] flex-wrap gap-[15px] xl:gap-5'>
-        {movieList?.length !== 0 ? (
-          movieList?.map((movie) => {
+        {productList?.length !== 0 ? (
+          productList?.map((movie) => {
             return (
               <li key={movie.id}>
                 <ProductCard movie={movie} />

--- a/src/app/(profile)/(component)/ProductList.tsx
+++ b/src/app/(profile)/(component)/ProductList.tsx
@@ -24,7 +24,7 @@ const ProductList = ({ userid, initialData }: Props) => {
     setOption(value);
   };
 
-  const { movieList, isFetching, fetchProducts, cursor } = useFetchUserProductList(
+  const { movieList, isFetching, fetchProducts, cursor, errOccur } = useFetchUserProductList(
     userid,
     option,
     initialData,
@@ -70,10 +70,14 @@ const ProductList = ({ userid, initialData }: Props) => {
         ) : (
           <div className='m-auto mt-15 h-60 w-60'>
             <Empty />
-            <p className='text-mogazoa-24px-400 mt-6 text-center'>목록이 없습니다</p>
+            <p className='text-mogazoa-24px-400 mt-6 text-center'>
+              {errOccur ? '잠시 후에 시도해주세요' : '목록이 없습니다'}
+            </p>
           </div>
         )}
-        {cursor !== null && <div ref={loadMoreRef} className='h-[5px] w-4'></div>}
+        {cursor !== null && errOccur === false && (
+          <div ref={loadMoreRef} className='h-[5px] w-4'></div>
+        )}
       </ul>
     </div>
   );

--- a/src/app/(profile)/(component)/ProductList.tsx
+++ b/src/app/(profile)/(component)/ProductList.tsx
@@ -60,17 +60,20 @@ const ProductList = ({ userid, initialData }: Props) => {
       </div>
       <ul className='flex max-w-[940px] flex-wrap gap-[15px] xl:gap-5'>
         {movieList?.length !== 0 ? (
-          movieList?.map((movie) => (
-            <li key={movie.id}>
-              <ProductCard movie={movie} />
-            </li>
-          ))
+          movieList?.map((movie) => {
+            return (
+              <li key={movie.id}>
+                <ProductCard movie={movie} />
+              </li>
+            );
+          })
         ) : (
           <div className='m-auto mt-15 h-60 w-60'>
             <Empty />
             <p className='text-mogazoa-24px-400 mt-6 text-center'>목록이 없습니다</p>
           </div>
         )}
+        {cursor !== null && <div ref={loadMoreRef}>로딩트리거어어어어어ㅓ</div>}
       </ul>
     </div>
   );

--- a/src/app/(profile)/(component)/ProductList.tsx
+++ b/src/app/(profile)/(component)/ProductList.tsx
@@ -5,8 +5,10 @@ import { useCallback, useRef, useState } from 'react';
 import Empty from '@/assets/icon/Icon-empty.svg';
 import SortDropdown from '@/components/common/dropdowns/SortDropdown';
 import ProductCard from '@/components/common/ProductCard';
+import { SORT_OPTION_USER_PAGE } from '@/constants/ProductsConst';
 import useFetchUserProductList from '@/hooks/useFetchUserProductList';
 import { useIntersectionObserver } from '@/hooks/useIntersectionObserver';
+import { cn } from '@/lib/utils';
 import { Product } from '@/types/product/productType';
 
 interface Props {
@@ -38,7 +40,23 @@ const ProductList = ({ userid, initialData }: Props) => {
   return (
     <div className='mb-30 md:mb-15'>
       <div className='text-mogazoa-18px-600 mt-15 mb-7.5 xl:mt-20'>
-        <SortDropdown variant={'user'} onChange={onValueChange} menuPosition='left' />
+        <div className='hidden gap-10 xl:flex'>
+          {SORT_OPTION_USER_PAGE.map(({ value, name }) => (
+            <button
+              key={`tab-${value}`}
+              className={cn('text-gray-6e6e82', value === option && 'text-white-f1f1f5')}
+              onClick={() => setOption(value)}
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+        <SortDropdown
+          variant={'user'}
+          menuPosition='left'
+          className='xl:hidden'
+          onChange={onValueChange}
+        />
       </div>
       <ul className='flex max-w-[940px] flex-wrap gap-[15px] xl:gap-5'>
         {movieList?.length !== 0 ? (

--- a/src/app/(profile)/(component)/ProductList.tsx
+++ b/src/app/(profile)/(component)/ProductList.tsx
@@ -53,7 +53,7 @@ const ProductList = ({ userid, initialData }: Props) => {
         </div>
         <SortDropdown
           variant={'user'}
-          menuPosition='right'
+          menuPosition='left'
           className='xl:hidden'
           onChange={onValueChange}
         />

--- a/src/app/(profile)/(component)/ProfileUpdateForm.tsx
+++ b/src/app/(profile)/(component)/ProfileUpdateForm.tsx
@@ -28,10 +28,10 @@ const ProfileUpdateForm = () => {
     register,
     handleSubmit,
     control,
-    formState: { errors, isDirty },
+    formState: { isDirty },
   } = useForm<ProfileFormValues>({
     resolver: zodResolver(profileSchema),
-    mode: 'onBlur',
+    mode: 'all',
     defaultValues: {
       nickname,
       description,
@@ -68,7 +68,8 @@ const ProfileUpdateForm = () => {
 
         <Input
           placeholder='닉네임을 입력해주세요'
-          errorMessage={errors.nickname?.message}
+          maxLength={10}
+          defaultValue={nickname}
           {...register('nickname')}
         />
 

--- a/src/app/(profile)/mypage/page.tsx
+++ b/src/app/(profile)/mypage/page.tsx
@@ -10,7 +10,7 @@ const Page = async () => {
   const userid = data.id;
   const parsedId = Number(userid);
 
-  const productData = await getUserProducts(parsedId, 'created-products');
+  const productData = await getUserProducts(parsedId, 'reviewed-products');
   const initialMoiveList = productData.list;
 
   return (
@@ -18,7 +18,7 @@ const Page = async () => {
       <ProfileCard userid={parsedId} myPage={true} />
       <div className='flex flex-col'>
         <Activities userid={parsedId} />
-        <ProductList userid={parsedId} initailData={initialMoiveList} />
+        <ProductList userid={parsedId} initialData={initialMoiveList} />
       </div>
     </div>
   );

--- a/src/app/(profile)/user/[userid]/page.tsx
+++ b/src/app/(profile)/user/[userid]/page.tsx
@@ -20,7 +20,7 @@ const Page = async ({ params }: Props) => {
       <ProfileCard userid={parsedId} />
       <div className='flex flex-col'>
         <Activities userid={parsedId} />
-        <ProductList userid={parsedId} initailData={initialMoiveList} />
+        <ProductList userid={parsedId} initialData={initialMoiveList} />
       </div>
     </div>
   );

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -62,6 +62,7 @@ const ErrorFallback = ({ error, reset, resetErrorBoundary }: Props) => {
 export default ErrorFallback;
 
 const errMap: { [key: string]: string } = {
+  400: `요청이 잘못 되었습니다`,
   401: `로그인이 필요합니다`,
   403: `권한이 없습니다 다시 로그인 해주세요`,
   404: `존재하지 않는 페이지입니다`,

--- a/src/components/common/FileInput.tsx
+++ b/src/components/common/FileInput.tsx
@@ -25,9 +25,12 @@ const FileInput = ({ maxFiles = 1, value, onChange }: FileInputProps) => {
     if (!e.target.files) return;
 
     const file = e.target.files[0];
+    const ext = file.name.split('.').pop(); //확장자 잡시 뽑아
+    const newFileName = `${Date.now()}-${Math.random().toString(36).substring(2)}.${ext}`; //다시 넣어
+    const renamedFile = new File([file], newFileName, { type: file.type });
 
     try {
-      const { url } = await postImageUrl(file);
+      const { url } = await postImageUrl(renamedFile);
       setFiles((prev) => {
         const updated = [...prev, url].slice(0, maxFiles);
         onChange(updated);

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -50,7 +50,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             {...props}
             onChange={(e) => {
               setCount(() => {
-                e.target.value = truncated(e.target.value, 10);
+                maxLength && (e.target.value = truncated(e.target.value, maxLength));
                 return e.target.value.length;
               });
               props.onChange?.(e);

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -6,20 +6,23 @@ import VisibilityIcon from '@/assets/icon/status=visibility_300.svg';
 import VisibilityOffIcon from '@/assets/icon/status=visibility_off_300.svg';
 import { Label } from '@/components/ui/label';
 import { cn } from '@/lib/utils';
+import { truncated } from '@/lib/utils/truncated';
 
 interface InputProps extends React.ComponentProps<'input'> {
   label?: string;
   errorMessage?: string;
   hintMessage?: string;
+  maxLength?: number;
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, id, label, errorMessage, hintMessage, ...props }, ref) => {
+  ({ className, type, id, label, errorMessage, hintMessage, maxLength, ...props }, ref) => {
     const generatedId = React.useId();
     const inputId = id || generatedId;
     const hasError = !!errorMessage;
     const [showPassword, setShowPassword] = React.useState(false);
     const inputType = type === 'password' ? (showPassword ? 'text' : 'password') : type;
+    const [count, setCount] = React.useState(props?.defaultValue?.toString().length ?? 0);
 
     return (
       <div className='flex w-full flex-col gap-[10px]'>
@@ -45,7 +48,20 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
             )}
             aria-invalid={hasError}
             {...props}
+            onChange={(e) => {
+              setCount(() => {
+                e.target.value = truncated(e.target.value, 10);
+                return e.target.value.length;
+              });
+              props.onChange?.(e);
+            }}
           />
+
+          {maxLength && (
+            <span className='text-gray-6e6e82 absolute right-3 bottom-2 text-xs'>
+              {count}/{maxLength}자
+            </span>
+          )}
           {type === 'password' && (
             <button
               type='button'

--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -11,7 +11,7 @@ interface Props {
 const ProductCard = ({ movie }: Props) => {
   return (
     <Link
-      href={`/products/${movie?.id}`}
+      href={`/products/${movie.id}`}
       className='border-black-353542 bg-black-252530 block rounded-[8px] p-2.5 xl:p-5'
     >
       {/* 컨텐츠 영화로 했을 때는 세로로 좀 더 길어야 할 것 같은데 고민이네요 */}
@@ -30,12 +30,12 @@ const ProductCard = ({ movie }: Props) => {
         </h3>
         <div className='text-mogazoa-12px-300 md:text-mogazoa-14px-300 xl:text-mogazoa-16px-300 text-gray-6e6e82 flex flex-col md:flex-row md:justify-between'>
           <div className='mb-[5px]'>
-            <span className='mr-2.5'>후기 {movie.reviewCount}</span>
+            <span className='mr-2.5'>후기 {Math.floor(movie.reviewCount)}</span>
             <span>찜 {movie.favoriteCount}</span>
           </div>
           <div className='text-yellow-ffc83c'>
             <StarIcon className='mr-[2px] inline-block h-3 w-3' />
-            <span className='text-gray-9fa6b2'>{movie?.rating}</span>
+            <span className='text-gray-9fa6b2'>{Math.floor(movie.rating)}</span>
           </div>
         </div>
       </div>

--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -9,6 +9,8 @@ interface Props {
 }
 
 const ProductCard = ({ movie }: Props) => {
+  const averageRating = Math.round(movie.rating * 10) / 10;
+
   return (
     <Link
       href={`/products/${movie.id}`}
@@ -35,7 +37,7 @@ const ProductCard = ({ movie }: Props) => {
           </div>
           <div className='text-yellow-ffc83c'>
             <StarIcon className='mr-[2px] inline-block h-3 w-3' />
-            <span className='text-gray-9fa6b2'>{Math.floor(movie.rating)}</span>
+            <span className='text-gray-9fa6b2'>{averageRating}</span>
           </div>
         </div>
       </div>

--- a/src/components/common/ProductCard.tsx
+++ b/src/components/common/ProductCard.tsx
@@ -25,7 +25,7 @@ const ProductCard = ({ movie }: Props) => {
         />
       </div>
       <div className='flex flex-col'>
-        <h3 className='text-mogazoa-14px-500 md:text-mogazoa-16px-500 xl:text-mogazoa-18px-500 mb-[5px]'>
+        <h3 className='text-mogazoa-14px-500 md:text-mogazoa-16px-500 xl:text-mogazoa-18px-500 mb-[5px] line-clamp-1 w-[140px] md:w-[227px] xl:w-[260px]'>
           {movie.name}
         </h3>
         <div className='text-mogazoa-12px-300 md:text-mogazoa-14px-300 xl:text-mogazoa-16px-300 text-gray-6e6e82 flex flex-col md:flex-row md:justify-between'>

--- a/src/hooks/useFetchUserProductList.ts
+++ b/src/hooks/useFetchUserProductList.ts
@@ -16,7 +16,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
     try {
       setIsFetching(true);
 
-      const data = await getUserProducts(userid, option);
+      const data = await getUserProducts(userid, option, cursor);
       setMovieList((prev) => [...(prev ?? []), ...data.list]);
 
       //cursor 업데이트
@@ -29,12 +29,13 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
     }
   };
 
+  //옵션 바뀔 때
   useEffect(() => {
     const fetchOptionChange = async () => {
       setIsFetching(true);
 
       try {
-        const data = await getUserProducts(userid, option);
+        const data = await getUserProducts(userid, option, cursor ?? 0);
         setMovieList(data.list);
         setCursor(data.nextCursor);
       } catch (err) {

--- a/src/hooks/useFetchUserProductList.ts
+++ b/src/hooks/useFetchUserProductList.ts
@@ -9,6 +9,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
   const [movieList, setMovieList] = useState(initialData);
   const [isFetching, setIsFetching] = useState(false);
   const [cursor, setCursor] = useState<number | null>(0);
+  const [errOccur, setErrOccur] = useState(false);
 
   const fetchProducts = async () => {
     if (cursor === null || isFetching) return;
@@ -40,6 +41,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
         setCursor(data.nextCursor);
       } catch (err) {
         console.log(err);
+        setErrOccur(true);
         setMovieList([]);
       } finally {
         setIsFetching(false);
@@ -50,7 +52,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
     // 여기에 커서는 들어가면 안도ㅒ!
   }, [option, userid]);
 
-  return { movieList, isFetching, fetchProducts, cursor };
+  return { movieList, isFetching, fetchProducts, cursor, errOccur };
 };
 
 export default useFetchUserProductList;

--- a/src/hooks/useFetchUserProductList.ts
+++ b/src/hooks/useFetchUserProductList.ts
@@ -24,6 +24,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
       setCursor(() => data.nextCursor);
     } catch (err) {
       console.log(err);
+      setErrOccur(true);
       setMovieList([]);
     } finally {
       setIsFetching(false);

--- a/src/hooks/useFetchUserProductList.ts
+++ b/src/hooks/useFetchUserProductList.ts
@@ -6,7 +6,7 @@ import { getUserProducts } from '@/actions/profile/getUserProducts';
 import { Product } from '@/types/product/productType';
 
 export const useFetchUserProductList = (userid: number, option: string, initialData: Product[]) => {
-  const [movieList, setMovieList] = useState(initialData);
+  const [productList, setProductList] = useState(initialData);
   const [isFetching, setIsFetching] = useState(false);
   const [cursor, setCursor] = useState<number | null>(0);
   const [errOccur, setErrOccur] = useState(false);
@@ -18,14 +18,14 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
       setIsFetching(true);
 
       const data = await getUserProducts(userid, option, cursor);
-      setMovieList((prev) => [...(prev ?? []), ...data.list]);
+      setProductList((prev) => [...(prev ?? []), ...data.list]);
 
       //cursor 업데이트
       setCursor(() => data.nextCursor);
     } catch (err) {
       console.log(err);
       setErrOccur(true);
-      setMovieList([]);
+      setProductList([]);
     } finally {
       setIsFetching(false);
     }
@@ -38,12 +38,12 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
 
       try {
         const data = await getUserProducts(userid, option, 0);
-        setMovieList(data.list);
+        setProductList(data.list);
         setCursor(data.nextCursor);
       } catch (err) {
         console.log(err);
         setErrOccur(true);
-        setMovieList([]);
+        setProductList([]);
       } finally {
         setIsFetching(false);
       }
@@ -53,7 +53,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
     // 여기에 커서는 들어가면 안도ㅒ!
   }, [option, userid]);
 
-  return { movieList, isFetching, fetchProducts, cursor, errOccur };
+  return { productList, isFetching, fetchProducts, cursor, errOccur };
 };
 
 export default useFetchUserProductList;

--- a/src/hooks/useFetchUserProductList.ts
+++ b/src/hooks/useFetchUserProductList.ts
@@ -35,7 +35,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
       setIsFetching(true);
 
       try {
-        const data = await getUserProducts(userid, option, cursor ?? 0);
+        const data = await getUserProducts(userid, option, 0);
         setMovieList(data.list);
         setCursor(data.nextCursor);
       } catch (err) {
@@ -47,6 +47,7 @@ export const useFetchUserProductList = (userid: number, option: string, initialD
     };
 
     fetchOptionChange();
+    // 여기에 커서는 들어가면 안도ㅒ!
   }, [option, userid]);
 
   return { movieList, isFetching, fetchProducts, cursor };

--- a/src/hooks/useFetchUserProductList.ts
+++ b/src/hooks/useFetchUserProductList.ts
@@ -1,0 +1,54 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { getUserProducts } from '@/actions/profile/getUserProducts';
+import { Product } from '@/types/product/productType';
+
+export const useFetchUserProductList = (userid: number, option: string, initialData: Product[]) => {
+  const [movieList, setMovieList] = useState(initialData);
+  const [isFetching, setIsFetching] = useState(false);
+  const [cursor, setCursor] = useState<number | null>(0);
+
+  const fetchProducts = async () => {
+    if (cursor === null || isFetching) return;
+
+    try {
+      setIsFetching(true);
+
+      const data = await getUserProducts(userid, option);
+      setMovieList((prev) => [...(prev ?? []), ...data.list]);
+
+      //cursor 업데이트
+      setCursor(() => data.nextCursor);
+    } catch (err) {
+      console.log(err);
+      setMovieList([]);
+    } finally {
+      setIsFetching(false);
+    }
+  };
+
+  useEffect(() => {
+    const fetchOptionChange = async () => {
+      setIsFetching(true);
+
+      try {
+        const data = await getUserProducts(userid, option);
+        setMovieList(data.list);
+        setCursor(data.nextCursor);
+      } catch (err) {
+        console.log(err);
+        setMovieList([]);
+      } finally {
+        setIsFetching(false);
+      }
+    };
+
+    fetchOptionChange();
+  }, [option, userid]);
+
+  return { movieList, isFetching, fetchProducts, cursor };
+};
+
+export default useFetchUserProductList;


### PR DESCRIPTION
## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/project-part4-team3/issue/LIN-51/user-profile-list-api

## 💡 변경 사항 요약

- 유저페이지 목록 리스트 리뷰한 상품 목록이 초기값으로
- 무한 스크롤 적용
- 드랍다운 연결 

(추가)
- 활동카드랑/ 프로덕트 카드 내부 별점 소수점 아래 버렸습니다
-> 소연님 피드백으로 수정했습니다

- 인풋 프롭에 maxLength 추가해서 
유저에게 닉네임 10자라는 피드백 주는 방식 바꿨습니다. (기존 텍스트 박스와 동일한 방식)
 맥스 프롭이 있을 때만 보이는거라 
다른 부분에 영향은 안 갈 것 같습니다.

<img width="603" height="134" alt="image" src="https://github.com/user-attachments/assets/fa1f0ca8-2334-4a9c-8c91-6d450b6d5215" />


- 파일인풋 한글이름으로 된 이미지 파일 넣으면 깨지는 이슈 수정했습니다



### 📌 세부 변경 내용

-

(소연님 피드백 반영)

-에러 폴백은 명확히
코멘트 달아주신 부분 try 안에 패칭 이후 throw new Error했을 때, 네트워크탭 쓰로틀링 오프라인일 때 두가지 경우의 모습

<img width="936" height="515" alt="image" src="https://github.com/user-attachments/assets/eb7ac07a-4c72-425b-96c4-f53c4d225c4b" />


-소수점 한 자리 반올림 (프로덕트 카드에도 반영 되어 있습니다.)/리뷰는 적용x 
<img width="961" height="656" alt="image" src="https://github.com/user-attachments/assets/793889ed-4da5-40be-a96c-23ebf8f62406" />
 
 

### 🧪 테스트 방법 및 결과 (선택 사항)

1.
2.

### 📸 스크린샷 (선택 사항)

데스크 탑

<img width="1920" height="988" alt="image" src="https://github.com/user-attachments/assets/f36628e3-32a2-4853-9008-4ae58dd5184d" />

태블릿 아래부턴 드랍다운으로
-> 수정하시면 자동으로 반영될 것 같아서 연결만 시켜두고 따로 건드리진 않았습니다.


<img width="1188" height="760" alt="image" src="https://github.com/user-attachments/assets/73a24fa0-9f68-4419-8cfb-f7b840c98c01" />


![KakaoTalk_Recording_20250830_172622-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/2bc058f7-3cbe-4de0-b3c7-4b8370788903)


### ✍️ 추가 코멘트 (선택 사항)

-
