### PR TITLE
Feat/lin 47 1차 QA 반영

### DIFF
--- a/src/app/(auth)/signin/page.tsx
+++ b/src/app/(auth)/signin/page.tsx
@@ -43,6 +43,12 @@ const SigninPage = () => {
     const result = await signIn(formData);
 
     if (result.success) {
+      // 헤더 내 로그인 정보 반영 위한 NextAuth session 갱신
+      await nextAuthSignIn('credentials', {
+        email: data.email,
+        password: data.password,
+        redirect: false,
+      });
       router.replace(result.redirectTo);
       return;
     }

--- a/src/app/_components/RatingRank.tsx
+++ b/src/app/_components/RatingRank.tsx
@@ -1,13 +1,15 @@
-import { getTopRatingProducts } from '@/actions/productRank';
 import ProductCard from '@/components/common/ProductCard';
+import { Product } from '@/types/product/productType';
 
 import ProductList from './ProductList';
 
-const RatingRank = async () => {
-  const topRated = await getTopRatingProducts();
+interface RatingRankProps {
+  products: Product[];
+}
 
+const RatingRank = ({ products }: RatingRankProps) => {
   // 오류 방어용 -> 추후 수정할 수 있음.
-  if (!topRated || topRated.length === 0) {
+  if (!products || products.length === 0) {
     return <p>랭킹 데이터가 없습니다.</p>;
   }
 
@@ -17,7 +19,7 @@ const RatingRank = async () => {
         별점이 높은 상품 <span className='text-mogazoa-24px-600 text-gradient'>TOP 6</span>
       </h1>
       <ProductList>
-        {topRated.map((p) => (
+        {products.map((p) => (
           <ProductCard key={p.id} movie={p} />
         ))}
       </ProductList>

--- a/src/app/_components/ResultTitle.tsx
+++ b/src/app/_components/ResultTitle.tsx
@@ -8,7 +8,7 @@ interface ResultTitleProps {
 const ResultTitle = ({ q, category }: ResultTitleProps) => {
   if (q && category !== null) {
     return (
-      <h2 className='text-mogazoa-24px-600 pt-[60px]'>
+      <h2 className='text-mogazoa-24px-600 md:pt-[60px]'>
         <span className='text-main-blue'>{getCategoryName(category)}</span> 내{' '}
         <span className='text-gradient'>&apos;{q}&apos;</span> 를(을) 검색한 결과입니다
       </h2>
@@ -16,14 +16,14 @@ const ResultTitle = ({ q, category }: ResultTitleProps) => {
   }
   if (q) {
     return (
-      <h2 className='text-mogazoa-24px-600 pt-[60px]'>
+      <h2 className='text-mogazoa-24px-600 md:pt-[60px]'>
         <span className='text-gradient'>&apos;{q}&apos;</span> 를(을) 검색한 결과입니다
       </h2>
     );
   }
   if (category !== null) {
     return (
-      <h2 className='text-mogazoa-24px-600 pt-[60px]'>
+      <h2 className='text-mogazoa-24px-600 md:pt-[60px]'>
         <span className='text-main-blue'>{getCategoryName(category)}</span> 내 상품목록입니다
       </h2>
     );

--- a/src/app/_components/ResultTitle.tsx
+++ b/src/app/_components/ResultTitle.tsx
@@ -10,14 +10,14 @@ const ResultTitle = ({ q, category }: ResultTitleProps) => {
     return (
       <h2 className='text-mogazoa-24px-600 pt-[60px]'>
         <span className='text-main-blue'>{getCategoryName(category)}</span> 내{' '}
-        <span className='text-gradient'>&apos;{q}&apos;</span>를(을) 검색한 결과입니다
+        <span className='text-gradient'>&apos;{q}&apos;</span> 를(을) 검색한 결과입니다
       </h2>
     );
   }
   if (q) {
     return (
       <h2 className='text-mogazoa-24px-600 pt-[60px]'>
-        <span className='text-gradient'>&apos;{q}&apos;</span>를(을) 검색한 결과입니다
+        <span className='text-gradient'>&apos;{q}&apos;</span> 를(을) 검색한 결과입니다
       </h2>
     );
   }

--- a/src/app/_components/ReviewRank.tsx
+++ b/src/app/_components/ReviewRank.tsx
@@ -1,13 +1,15 @@
-import { getTopReviewedProducts } from '@/actions/productRank';
 import ProductCard from '@/components/common/ProductCard';
+import { Product } from '@/types/product/productType';
 
 import ProductList from './ProductList';
 
-const ReviewRank = async () => {
-  const topReviewed = await getTopReviewedProducts();
+interface ReviewRankProps {
+  products: Product[];
+}
 
+const ReviewRank = ({ products }: ReviewRankProps) => {
   // 오류 방어용 -> 추후 수정할 수 있음.
-  if (!topReviewed || topReviewed.length === 0) {
+  if (!products || products.length === 0) {
     return <p>랭킹 데이터가 없습니다.</p>;
   }
 
@@ -17,7 +19,7 @@ const ReviewRank = async () => {
         지금 핫한 상품 <span className='text-mogazoa-24px-600 text-gradient'>TOP 6</span>
       </h1>
       <ProductList>
-        {topReviewed.map((p) => (
+        {products.map((p) => (
           <ProductCard key={p.id} movie={p} />
         ))}
       </ProductList>

--- a/src/app/_components/Sidebar.tsx
+++ b/src/app/_components/Sidebar.tsx
@@ -7,9 +7,9 @@ const Sidebar = ({ selected, q }: { selected: number | null; q: string }) => {
   const { navigateToCategory } = useCategoryNavigation();
 
   return (
-    <aside className='sticky top-[80px] hidden h-fit w-[clamp(250px,25vw,350px)] pt-[45px] md:flex md:justify-end xl:top-[100px]'>
+    <aside className='sticky top-[45px] hidden h-fit w-[clamp(250px,25vw,350px)] pt-[45px] md:flex md:justify-end xl:top-[100px]'>
       <div className='flex flex-col'>
-        <p className='text-mogazoa-16px-400'>카테고리</p>
+        <p className='text-mogazoa-16px-400 px-[20px] pb-[20px]'>카테고리</p>
         {/* 변경된 카테고리 이름으로 변경하고 map*/}
         {Object.entries(CATEGORY_NAME_MAP).map(([id, label]) => {
           const numId = Number(id);
@@ -18,7 +18,7 @@ const Sidebar = ({ selected, q }: { selected: number | null; q: string }) => {
           return (
             <button
               key={id}
-              className={`h-[50px] w-[200px] rounded-md px-[20px] py-[15px] text-left ${isSelected ? 'text-white-f1f1f5 bg-black-353542' : 'text-gray-6e6e82'}`}
+              className={`h-[50px] w-[220px] rounded-md py-[15px] pl-[20px] text-left ${isSelected ? 'text-white-f1f1f5 bg-black-353542' : 'text-gray-6e6e82'}`}
               onClick={() => navigateToCategory(isSelected ? null : numId, q)}
             >
               {label}

--- a/src/app/_components/reviewer/ReviewerCard.tsx
+++ b/src/app/_components/reviewer/ReviewerCard.tsx
@@ -38,9 +38,12 @@ const ReviewerCard = ({
             />
           )}
           <div className='flex flex-col gap-[5.5px] xl:gap-[9px]'>
-            <div className='flex gap-[5px]'>
+            <div className='flex gap-[7px]'>
               <RankingChip idx={rankIdx} />
-              <h3 className='text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5'>
+              <h3
+                className='text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5 max-w-20 truncate xl:max-w-24'
+                title={nickname}
+              >
                 {nickname}
               </h3>
             </div>

--- a/src/app/compare/components/CompareConfirmModal.tsx
+++ b/src/app/compare/components/CompareConfirmModal.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import Button from '@/components/ui/Buttons';
+import { useModalStore } from '@/store/modalStore';
+
+const CompareConfirmModal = () => {
+  const { closeModal } = useModalStore();
+  const router = useRouter();
+
+  const handleConfirm = () => {
+    closeModal();
+    router.push('/compare');
+  };
+
+  const handleCancel = () => {
+    closeModal();
+  };
+
+  return (
+    <div>
+      <h2>비교하기</h2>
+      <p>비교하러 가시겠습니까?</p>
+      <div className='flex gap-3'>
+        <Button variant='tertiary' onClick={handleCancel} className='flex-1'>
+          취소
+        </Button>
+        <Button variant='primary' onClick={handleConfirm} className='flex-1'>
+          비교하러 가기
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default CompareConfirmModal;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import { SpeedInsights } from '@vercel/speed-insights/next';
 import { SessionProvider } from 'next-auth/react';
 
 import { auth } from '@/auth'; // NextAuth의 서버 함수 임포트
-import AuthHydration from '@/components/AuthHydration';
 import GlobalNav from '@/components/common/gnb/GlobalNav';
 import ModalContainer from '@/components/common/ModalContainer';
 import SonnerToast from '@/components/common/SonnerToast';
@@ -30,8 +29,7 @@ export default async function RootLayout({
       <body className={pretendard.variable}>
         <SessionProvider session={session}>
           {/* 서버 컴포넌트에서 세션 정보를 가져와 클라이언트 컴포넌트에 전달 */}
-          <AuthHydration session={session} />
-          <GlobalNav session={session} />
+          <GlobalNav />
           {children}
           <FloatingButton />
           <SonnerToast />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,4 @@
+import { getTopReviewedProducts, getTopRatingProducts } from '@/actions/productRank';
 import { getReviewerRanking } from '@/actions/review/reviewer';
 import FloatingButton from '@/components/ui/FloatingButton';
 
@@ -16,13 +17,19 @@ const Home = async ({
 }: {
   searchParams: Promise<{ q?: string; categoryId?: string; cursor?: string }>;
 }) => {
-  const users = await getReviewerRanking();
   const params = await searchParams;
   const q = params.q ?? '';
   const category = params.categoryId ? Number(params.categoryId) : null;
   const cursor = params.cursor ? Number(params.cursor) : null;
 
-  const data = await searchProducts({ q, category, cursor });
+  // API 병렬 호출
+  const [users, data, topReviewed, topRated] = await Promise.all([
+    getReviewerRanking(),
+    searchProducts({ q, category, cursor }),
+    getTopReviewedProducts(),
+    getTopRatingProducts(),
+  ]);
+
   const items = data.list;
 
   return (
@@ -35,8 +42,8 @@ const Home = async ({
             <div className='flex flex-col'>
               <MobileCategoryFilter className='mb-6 md:hidden' />
               <div className='flex flex-col gap-[80px]'>
-                <ReviewRank />
-                <RatingRank />
+                <ReviewRank products={topReviewed} />
+                <RatingRank products={topRated} />
               </div>
             </div>
           ) : items.length === 0 ? (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,21 +37,18 @@ const Home = async ({
       <div className='flex items-start gap-6'>
         <Sidebar selected={category} q={q} />
         <section className='min-w-0 flex-1 overflow-hidden px-[20px]'>
-          <ReviewerRank users={users} className='mb-6 pt-[40px] xl:hidden' />
+          <ReviewerRank users={users} className='mb-6 pt-[40px] pb-3 xl:hidden' />
+          <MobileCategoryFilter className='mb-3 md:hidden' />
           {q === '' && category === null ? (
-            <div className='flex flex-col'>
-              <MobileCategoryFilter className='mb-6 md:hidden' />
-              <div className='flex flex-col gap-[80px]'>
-                <ReviewRank products={topReviewed} />
-                <RatingRank products={topRated} />
-              </div>
+            <div className='flex flex-col gap-[80px]'>
+              <ReviewRank products={topReviewed} />
+              <RatingRank products={topRated} />
             </div>
           ) : items.length === 0 ? (
             <NoResult />
           ) : (
             <div>
               <ResultTitle category={category} q={q} />
-              <MobileCategoryFilter className='mt-3 md:hidden' />
               <SearchResultList
                 initialProducts={items}
                 initialCursor={data.nextCursor}

--- a/src/app/products/[productId]/components/AddToCompareButton.tsx
+++ b/src/app/products/[productId]/components/AddToCompareButton.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { toast } from 'sonner';
+
+import CompareConfirmModal from '@/app/compare/components/CompareConfirmModal';
+import Button from '@/components/ui/Buttons';
+import { useCompareStore } from '@/store/compareStore';
+import { useModalStore } from '@/store/modalStore';
+import { Product } from '@/types/product/productType';
+
+interface AddToCompareButtonProps {
+  product: Product;
+  className?: string;
+}
+
+const AddToCompareButton = ({ product, className }: AddToCompareButtonProps) => {
+  const { compareList, addProduct, undoRemove } = useCompareStore();
+  const { openModal } = useModalStore();
+
+  const handleAddToCompare = () => {
+    const currentCount = compareList.length;
+
+    // 이미 담긴 상품인지 확인
+    if (compareList.some((p) => p.id === product.id)) {
+      toast.info('이미 저장된 항목입니다. "비교하기"에서 확인해주세요.');
+      return;
+    }
+
+    if (currentCount === 0) {
+      addProduct(product);
+      toast.info('비교대상을 추가해주세요');
+      return;
+    }
+
+    if (currentCount >= 4) {
+      const result = addProduct(product);
+      if (result.removedProduct) {
+        toast.warning(
+          `비교하기는 최대 4개까지 저장. "${result.removedProduct.name}"이(가) 삭제되었습니다.`,
+          {
+            action: {
+              label: 'Undo',
+              onClick: () => undoRemove(result.removedProduct!, product),
+            },
+            style: {
+              '--action-button-color': '#3b82f6',
+              '--action-button-color-hover': '#2563eb',
+            } as React.CSSProperties,
+          },
+        );
+      }
+      return;
+    }
+
+    addProduct(product);
+
+    if (currentCount >= 1) {
+      // 2개 이상일 때 확인 모달
+      openModal({
+        component: CompareConfirmModal,
+        props: {},
+      });
+    }
+  };
+
+  return (
+    <Button variant='secondary' type='button' className={className} onClick={handleAddToCompare}>
+      비교하기
+    </Button>
+  );
+};
+
+export default AddToCompareButton;

--- a/src/app/products/[productId]/components/ProductTriggers.tsx
+++ b/src/app/products/[productId]/components/ProductTriggers.tsx
@@ -4,6 +4,7 @@ import Button from '@/components/ui/Buttons';
 import { useModalStore } from '@/store/modalStore';
 import { ProductDetail } from '@/types/product/productType';
 
+import AddToCompareButton from './AddToCompareButton';
 import ReviewPostModal from './ReviewPostModal';
 
 const ProductTriggers = ({ product }: { product: ProductDetail }) => {
@@ -23,9 +24,7 @@ const ProductTriggers = ({ product }: { product: ProductDetail }) => {
       >
         리뷰 작성하기
       </Button>
-      <Button variant='secondary' type='button' className='md:flex-1'>
-        비교하기
-      </Button>
+      <AddToCompareButton product={product} className='md:flex-1' />
       {product.writerId === 1 && (
         <Button variant='tertiary' type='button' className='md:flex-1'>
           편집하기

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -4,6 +4,7 @@ import { getProductDetail } from '@/actions/productDetail';
 import { getProductReviews } from '@/actions/review/review';
 import CategoryChip from '@/components/ui/chips/CategoryChip';
 
+import AddToCompareButton from './components/AddToCompareButton';
 import FavoriteButton from './components/FavoriteButton';
 import MetricCard from './components/MetricCard';
 import ProductTriggers from './components/ProductTriggers';

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -4,7 +4,6 @@ import { getProductDetail } from '@/actions/productDetail';
 import { getProductReviews } from '@/actions/review/review';
 import CategoryChip from '@/components/ui/chips/CategoryChip';
 
-import AddToCompareButton from './components/AddToCompareButton';
 import FavoriteButton from './components/FavoriteButton';
 import MetricCard from './components/MetricCard';
 import ProductTriggers from './components/ProductTriggers';

--- a/src/components/common/gnb/DesktopNav.tsx
+++ b/src/components/common/gnb/DesktopNav.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react';
+
+interface DesktopNavProps {
+  left: ReactNode;
+  center: ReactNode;
+  right: ReactNode;
+}
+
+const DesktopNav = ({ left, center, right }: DesktopNavProps) => {
+  return (
+    <>
+      <div className='hidden w-2/7 items-center gap-2 md:flex xl:w-2/12'>{left}</div>
+      <div className='hidden w-3/7 items-center justify-end md:flex xl:w-8/12'>{center}</div>
+      <div className='hidden w-2/7 items-center justify-end gap-2 px-3 md:flex xl:w-2/12'>
+        {right}
+      </div>
+    </>
+  );
+};
+
+export default DesktopNav;

--- a/src/components/common/gnb/DesktopNav.tsx
+++ b/src/components/common/gnb/DesktopNav.tsx
@@ -8,13 +8,13 @@ interface DesktopNavProps {
 
 const DesktopNav = ({ left, center, right }: DesktopNavProps) => {
   return (
-    <>
-      <div className='hidden w-2/7 items-center gap-2 md:flex xl:w-2/12'>{left}</div>
-      <div className='hidden w-3/7 items-center justify-end md:flex xl:w-8/12'>{center}</div>
-      <div className='hidden w-2/7 items-center justify-end gap-2 px-3 md:flex xl:w-2/12'>
+    <div className='hidden w-full items-center justify-between md:flex'>
+      <div>{left}</div>
+      <div className='flex items-center md:gap-[30px] xl:gap-[60px]'>
+        {center}
         {right}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/common/gnb/GlobalNav.tsx
+++ b/src/components/common/gnb/GlobalNav.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import DesktopNav from './DesktopNav';
 import MobileNav from './MobileNav';
 import DesktopCenter from './section/DesktopCenter';

--- a/src/components/common/gnb/GlobalNav.tsx
+++ b/src/components/common/gnb/GlobalNav.tsx
@@ -7,8 +7,11 @@ import MobileRight from './section/MobileRight';
 
 import type { Session } from 'next-auth';
 
-const GlobalNav = ({ session }: { session: Session | null }) => {
-  const isLoggedIn = !!session;
+interface GlobalNavProps {
+  session: Session | null;
+}
+
+const GlobalNav = ({ session }: GlobalNavProps) => {
   return (
     <header className='border-black-2e2e3a md:px=[30px] bg-black-1c1c22 sticky top-0 z-50 h-[70px] border-b-2 shadow-sm shadow-black md:h-[80px] xl:h-[100px] xl:px-[120px]'>
       <div className='mx-auto flex h-full items-center gap-4 px-5'>
@@ -30,7 +33,7 @@ const GlobalNav = ({ session }: { session: Session | null }) => {
           <DesktopCenter />
         </div>
         <div className='hidden w-2/7 items-center justify-end gap-2 px-3 md:flex xl:w-2/12'>
-          <DesktopRight isLoggedIn={isLoggedIn} />
+          <DesktopRight session={session} />
         </div>
       </div>
     </header>

--- a/src/components/common/gnb/GlobalNav.tsx
+++ b/src/components/common/gnb/GlobalNav.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import DesktopNav from './DesktopNav';
+import MobileNav from './MobileNav';
 import DesktopCenter from './section/DesktopCenter';
 import DesktopLeft from './section/DesktopLeft';
 import DesktopRight from './section/DesktopRight';
@@ -5,36 +9,12 @@ import MobileCenter from './section/MobileCenter';
 import MobileLeft from './section/MobileLeft';
 import MobileRight from './section/MobileRight';
 
-import type { Session } from 'next-auth';
-
-interface GlobalNavProps {
-  session: Session | null;
-}
-
-const GlobalNav = ({ session }: GlobalNavProps) => {
+const GlobalNav = () => {
   return (
     <header className='border-black-2e2e3a md:px=[30px] bg-black-1c1c22 sticky top-0 z-50 h-[70px] border-b-2 shadow-sm shadow-black md:h-[80px] xl:h-[100px] xl:px-[120px]'>
       <div className='mx-auto flex h-full items-center gap-4 px-5'>
-        {/*모바일*/}
-        <div className='flex items-center gap-2 md:hidden'>
-          <MobileLeft session={session} />
-        </div>
-        <div className='grid flex-1 place-items-center md:hidden'>
-          <MobileCenter />
-        </div>
-        <div className='flex items-center gap-1 md:hidden'>
-          <MobileRight />
-        </div>
-        {/*데스크톱*/}
-        <div className='hidden w-2/7 items-center gap-2 md:flex xl:w-2/12'>
-          <DesktopLeft />
-        </div>
-        <div className='hidden w-3/7 items-center justify-end md:flex xl:w-8/12'>
-          <DesktopCenter />
-        </div>
-        <div className='hidden w-2/7 items-center justify-end gap-2 px-3 md:flex xl:w-2/12'>
-          <DesktopRight session={session} />
-        </div>
+        <MobileNav left={<MobileLeft />} center={<MobileCenter />} right={<MobileRight />} />
+        <DesktopNav left={<DesktopLeft />} center={<DesktopCenter />} right={<DesktopRight />} />
       </div>
     </header>
   );

--- a/src/components/common/gnb/MobileNav.tsx
+++ b/src/components/common/gnb/MobileNav.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react';
+
+interface MobileNavProps {
+  left: ReactNode;
+  center: ReactNode;
+  right: ReactNode;
+}
+
+const MobileNav = ({ left, center, right }: MobileNavProps) => {
+  return (
+    <>
+      <div className='flex items-center gap-2 md:hidden'>{left}</div>
+      <div className='grid flex-1 place-items-center md:hidden'>{center}</div>
+      <div className='flex items-center gap-1 md:hidden'>{right}</div>
+    </>
+  );
+};
+
+export default MobileNav;

--- a/src/components/common/gnb/buttons/CompareButton.tsx
+++ b/src/components/common/gnb/buttons/CompareButton.tsx
@@ -2,7 +2,10 @@ import Link from 'next/link';
 
 const CompareButton = () => {
   return (
-    <Link href='/compare' className='text-mogazoa-18px-400 py-1 whitespace-nowrap'>
+    <Link
+      href='/compare'
+      className='md:text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5 whitespace-nowrap'
+    >
       비교하기
     </Link>
   );

--- a/src/components/common/gnb/buttons/LoginButton.tsx
+++ b/src/components/common/gnb/buttons/LoginButton.tsx
@@ -1,6 +1,13 @@
 import Link from 'next/link';
 
 const LoginButton = () => {
-  return <Link href='/signin'>로그인</Link>;
+  return (
+    <Link
+      href='/signin'
+      className='md:text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5'
+    >
+      로그인
+    </Link>
+  );
 };
 export default LoginButton;

--- a/src/components/common/gnb/buttons/LogoButton.tsx
+++ b/src/components/common/gnb/buttons/LogoButton.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 const LogoButton = () => {
   return (
-    <Link href='/'>
+    <Link href='/' className='flex items-center'>
       <Image src='/icon/Logo.svg' alt='Logo' width={166} height={28} />
     </Link>
   );

--- a/src/components/common/gnb/buttons/SignupButton.tsx
+++ b/src/components/common/gnb/buttons/SignupButton.tsx
@@ -1,7 +1,14 @@
 import Link from 'next/link';
 
 const SignupButton = () => {
-  return <Link href='/signup'>회원가입</Link>;
+  return (
+    <Link
+      href='/signup'
+      className='md:text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5'
+    >
+      회원가입
+    </Link>
+  );
 };
 
 export default SignupButton;

--- a/src/components/common/gnb/mobileMenu/MobileMenu.tsx
+++ b/src/components/common/gnb/mobileMenu/MobileMenu.tsx
@@ -9,17 +9,26 @@ import MobileMenuList from './MobileMenuList';
 
 const MobileMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const [isClosing, setIsClosing] = useState(false);
   const { data: session } = useSession();
 
   const isLoggedIn = !!session;
   const name = session?.user?.nickname ?? null;
   const profileUrl = session?.user?.image ?? null;
 
+  const handleClose = () => {
+    setIsClosing(true);
+    setTimeout(() => {
+      setIsOpen(false);
+      setIsClosing(false);
+    }, 300);
+  };
+
   return (
     <div>
       <button
         type='button'
-        onClick={() => setIsOpen((prev) => !prev)}
+        onClick={() => (isOpen ? handleClose() : setIsOpen(true))}
         aria-expanded={isOpen}
         aria-label='모바일 메뉴 열기/닫기'
         className='cursor-pointer'
@@ -30,15 +39,21 @@ const MobileMenu = () => {
         <>
           {/* 오버레이 */}
           <div
-            className='fixed top-[70px] right-0 bottom-0 left-0 z-40 bg-black/50'
-            onClick={() => setIsOpen(false)}
+            className={`fixed top-[70px] right-0 bottom-0 left-0 z-40 bg-black/50 duration-300 ${
+              isClosing ? 'animate-out fade-out' : 'animate-in fade-in'
+            }`}
+            onClick={handleClose}
           />
           {/* 사이드 메뉴 */}
-          <aside className='bg-black-252530 animate-in slide-in-from-left fixed top-[70px] bottom-0 left-0 z-50 w-80 duration-300 ease-out'>
+          <aside
+            className={`bg-black-252530 fixed top-[70px] bottom-0 left-0 z-50 w-80 duration-300 ease-out ${
+              isClosing ? 'animate-out slide-out-to-left' : 'animate-in slide-in-from-left'
+            }`}
+          >
             {/* X 버튼 */}
             <div className='flex justify-end p-4'>
               <button
-                onClick={() => setIsOpen(false)}
+                onClick={handleClose}
                 aria-label='메뉴 닫기'
                 className='text-white-f1f1f5 hover:text-gray-9fa6b2 cursor-pointer'
               >
@@ -51,7 +66,7 @@ const MobileMenu = () => {
                 isLoggedIn={isLoggedIn}
                 name={name}
                 profileUrl={profileUrl}
-                onClose={() => setIsOpen(false)}
+                onClose={handleClose}
               />
             </div>
           </aside>

--- a/src/components/common/gnb/mobileMenu/MobileMenu.tsx
+++ b/src/components/common/gnb/mobileMenu/MobileMenu.tsx
@@ -3,17 +3,13 @@
 import { useState } from 'react';
 
 import { Menu, X } from 'lucide-react';
+import { useSession } from 'next-auth/react';
 
 import MobileMenuList from './MobileMenuList';
 
-import type { Session } from 'next-auth';
-
-interface MobileMenuProps {
-  session: Session | null;
-}
-
-const MobileMenu = ({ session }: MobileMenuProps) => {
+const MobileMenu = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { data: session } = useSession();
 
   const isLoggedIn = !!session;
   const name = session?.user?.nickname ?? null;

--- a/src/components/common/gnb/mobileMenu/MobileMenu.tsx
+++ b/src/components/common/gnb/mobileMenu/MobileMenu.tsx
@@ -16,7 +16,7 @@ const MobileMenu = ({ session }: MobileMenuProps) => {
   const [isOpen, setIsOpen] = useState(false);
 
   const isLoggedIn = !!session;
-  const name = session?.user?.name ?? null;
+  const name = session?.user?.nickname ?? null;
   const profileUrl = session?.user?.image ?? null;
 
   return (

--- a/src/components/common/gnb/mobileMenu/MobileMenuList.tsx
+++ b/src/components/common/gnb/mobileMenu/MobileMenuList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Link from 'next/link';
+import { signOut } from 'next-auth/react';
 
 import AvatarProfile from '../profile/AvatarProfile';
 
@@ -73,12 +74,14 @@ const MobileMenuList = ({
             </li>
             <li>
               <button
-                onClick={onClose}
+                onClick={() => {
+                  onClose();
+                  signOut();
+                }}
                 className='hover:bg-black-353542 text-white-f1f1f5 text-mogazoa-18px-400 w-full rounded-lg px-4 py-3 text-left transition-colors'
               >
                 로그아웃
               </button>
-              {/* <button onClick={()=> signOut()}>로그아웃</button> -> auth 세팅 이후 사용 */}
             </li>
           </ul>
         </div>

--- a/src/components/common/gnb/profile/AvatarProfile.tsx
+++ b/src/components/common/gnb/profile/AvatarProfile.tsx
@@ -11,12 +11,15 @@ interface AvatarProfileProps {
 
 const AvatarProfile = ({ profileImg = null, userName }: AvatarProfileProps) => {
   return (
-    <div className='flex items-center gap-2 whitespace-nowrap'>
-      <Avatar className='border-white-f1f1f5 xl:h- h-12 w-12 border-2 border-solid md:h-8 md:w-8 xl:w-8'>
+    <div className='flex items-center gap-4 whitespace-nowrap md:gap-2'>
+      <Avatar className='border-white-f1f1f5 h-10 w-10 border-2 border-solid md:h-7 md:w-7 xl:w-8'>
         <AvatarImage src={profileImg ?? 'icon/GuestProfile.svg'} alt='프로필 이미지' />
         <AvatarFallback>GU</AvatarFallback>
       </Avatar>
-      <span className='text-mogazoa-14px-400 md:text-mogazoa-14px-400 xl:text-mogazoa-18px-400'>
+      <span
+        className='text-mogazoa-18px-400 md:text-mogazoa-14px-400 xl:text-mogazoa-16px-400 max-w-45 truncate md:max-w-16 xl:max-w-23' // 모바일은 사실상 truncate 없음. -> 테스트필요
+        title={userName ?? '게스트'}
+      >
         {userName ?? '게스트'}
       </span>
     </div>

--- a/src/components/common/gnb/profile/ProfileDropdown.tsx
+++ b/src/components/common/gnb/profile/ProfileDropdown.tsx
@@ -3,41 +3,25 @@
 import { useRef, useState } from 'react';
 
 import Link from 'next/link';
+import { signOut } from 'next-auth/react';
 
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
-// import { signOut } from "next-auth/react" -> auth 세팅 이후 다시 확인
 
 import AvatarProfile from './AvatarProfile';
-// import { useAuthStore } from '@/store/auth'; -> 유저 정보 제작 후 교체
 
-interface AuthState {
-  isLoggedIn: boolean;
-  name?: string | null;
-  profileUrl?: string | null;
+import type { Session } from 'next-auth';
+
+interface ProfileDropdownProps {
+  session: Session | null;
 }
 
-function useAuth(): AuthState {
-  // const isLoggedIn = useAuthStore((s) => Boolean(s.session));
-  // const name = useAuthStore((s) => s.user?.name ?? null);
-  // const profileUrl = useAuthStore((s) => s.user?.profileImg ?? null);
-  // return { isLoggedIn, name, profileUrl };
-
-  return { isLoggedIn: false, name: null, profileUrl: null }; // 임시 더미데이터
-}
-
-const ProfileDropdown = () => {
+const ProfileDropdown = ({ session }: ProfileDropdownProps) => {
   const [listOpen, setListOpen] = useState(false);
-  const { isLoggedIn, name, profileUrl } = useAuth();
   const ref = useRef<HTMLDivElement | null>(null);
-
-  // 린트 에러 방지
-  console.log(name);
-  console.log(profileUrl);
 
   useOnClickOutside(ref, () => {
     setListOpen(false);
   });
-  // const user = useAuthStore((s) => s.user); -> AvatarProfile로 유저 정보 내려줌
 
   return (
     <div className='relative'>
@@ -48,8 +32,7 @@ const ProfileDropdown = () => {
         onClick={() => setListOpen((open) => !open)}
         className='cursor-pointer'
       >
-        <AvatarProfile />
-        {/* <AvatarProfile profileImg={user?.profileImg} userName={user?.userName} /> */}
+        <AvatarProfile profileImg={session?.user?.image} userName={session?.user?.nickname} />
       </button>
       {listOpen && (
         <div
@@ -58,32 +41,21 @@ const ProfileDropdown = () => {
           className='border-black-353542 bg-black-252530 absolute top-13 left-0 z-10 w-36 rounded-lg border px-2 py-2 xl:right-[120px]'
         >
           <ul>
-            {isLoggedIn ? (
-              <div>
-                <li className='hover:bg-black-353542 text-white-f1f1f5 rounded-lg px-2 py-1'>
-                  <Link href='/mypage' onClick={() => setListOpen(false)}>
-                    내 프로필
-                  </Link>
-                </li>
-                <li className='hover:bg-black-353542 text-white-f1f1f5 rounded-lg px-2 py-1'>
-                  <button onClick={() => setListOpen(false)}>로그아웃</button>
-                  {/* <button onClick={()=> signOut()}>로그아웃</button> -> auth 세팅 이후 사용 */}
-                </li>
-              </div>
-            ) : (
-              <div>
-                <li className='hover:bg-black-353542 text-white-f1f1f5 rounded-lg px-2 py-1'>
-                  <Link href='/signin' onClick={() => setListOpen(false)}>
-                    로그인
-                  </Link>
-                </li>
-                <li className='hover:bg-black-353542 text-white-f1f1f5 rounded-lg px-2 py-1'>
-                  <Link href='/signup' onClick={() => setListOpen(false)}>
-                    회원가입
-                  </Link>
-                </li>
-              </div>
-            )}
+            <li className='hover:bg-black-353542 text-white-f1f1f5 rounded-lg px-2 py-1'>
+              <Link href='/mypage' onClick={() => setListOpen(false)}>
+                내 프로필
+              </Link>
+            </li>
+            <li className='hover:bg-black-353542 text-white-f1f1f5 rounded-lg px-2 py-1'>
+              <button
+                onClick={() => {
+                  setListOpen(false);
+                  signOut();
+                }}
+              >
+                로그아웃
+              </button>
+            </li>
           </ul>
         </div>
       )}

--- a/src/components/common/gnb/searchForm/SearchSuggestions.tsx
+++ b/src/components/common/gnb/searchForm/SearchSuggestions.tsx
@@ -2,6 +2,7 @@
 
 import { useRef } from 'react';
 
+import CategoryChip from '@/components/ui/chips/CategoryChip';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
 import { getCategoryName } from '@/lib/utils/categoryNameMap';
 
@@ -42,9 +43,8 @@ const SearchSuggestions = ({
             <span>
               <Highlight text={p.name} query={query} />
             </span>
-            <span className='bg-main-blue text-mogazoa-12px-400 ml-2 rounded px-2 py-0.5'>
-              {/* 카테고리 이름 변경 */}
-              {getCategoryName(p.categoryId)}
+            <span>
+              <CategoryChip category={{ id: p.categoryId, name: getCategoryName(p.categoryId) }} />
             </span>
           </button>
         </li>

--- a/src/components/common/gnb/searchForm/SearchSuggestions.tsx
+++ b/src/components/common/gnb/searchForm/SearchSuggestions.tsx
@@ -1,10 +1,9 @@
 'use client';
 
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import CategoryChip from '@/components/ui/chips/CategoryChip';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
-import { getCategoryName } from '@/lib/utils/categoryNameMap';
 
 import Highlight from './Highlight';
 
@@ -20,10 +19,48 @@ const SearchSuggestions = ({
   onClose: () => void;
 }) => {
   const ref = useRef<HTMLUListElement | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [isKeyboardMode, setIsKeyboardMode] = useState(false);
 
   useOnClickOutside(ref, () => {
     onClose();
   });
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (!suggestions.length) return;
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setIsKeyboardMode(true);
+          setSelectedIndex((prev) => (prev < suggestions.length - 1 ? prev + 1 : 0));
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setIsKeyboardMode(true);
+          setSelectedIndex((prev) => (prev > 0 ? prev - 1 : suggestions.length - 1));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (selectedIndex >= 0) {
+            onSelect(suggestions[selectedIndex].name);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          onClose();
+          break;
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [suggestions, selectedIndex, onSelect, onClose]);
+
+  useEffect(() => {
+    setSelectedIndex(-1);
+  }, [suggestions]);
 
   if (!query || suggestions.length === 0) return null;
 
@@ -33,18 +70,29 @@ const SearchSuggestions = ({
       role='listbox'
       className='bg-black-252530 border-black-353542 absolute z-50 mt-1 w-full rounded-md border'
     >
-      {suggestions.slice(0, 8).map((p) => (
+      {suggestions.slice(0, 8).map((p, index) => (
         <li key={p.id}>
           <button
-            // role='option'
-            className='hover:bg-black-353542 flex w-full cursor-pointer items-center justify-between px-3 py-2 text-left hover:rounded-md'
+            role='option'
+            aria-selected={selectedIndex === index}
+            className={`flex w-full cursor-pointer items-center justify-between rounded-md px-3 py-2 text-left ${
+              selectedIndex === index ? 'bg-black-353542' : ''
+            }`}
+            onMouseEnter={() => {
+              if (!isKeyboardMode) setSelectedIndex(index);
+            }}
+            onMouseMove={() => {
+              setIsKeyboardMode(false);
+              setSelectedIndex(index);
+            }}
+            onMouseLeave={() => setSelectedIndex(-1)}
             onClick={() => onSelect(p.name)}
           >
             <span>
               <Highlight text={p.name} query={query} />
             </span>
             <span>
-              <CategoryChip category={{ id: p.categoryId, name: getCategoryName(p.categoryId) }} />
+              <CategoryChip category={{ id: p.categoryId, name: '' }} />
             </span>
           </button>
         </li>

--- a/src/components/common/gnb/section/DesktopRight.tsx
+++ b/src/components/common/gnb/section/DesktopRight.tsx
@@ -13,12 +13,12 @@ const DesktopRight = () => {
   return (
     <div>
       {/* guest */}
-      <div className={isLoggedIn ? 'hidden' : 'flex gap-5'}>
+      <div className={isLoggedIn ? 'hidden' : 'flex md:gap-[30px] xl:gap-[60px]'}>
         <LoginButton />
         <SignupButton />
       </div>
       {/* auth */}
-      <div className={isLoggedIn ? 'flex gap-5' : 'hidden'}>
+      <div className={isLoggedIn ? 'flex items-center md:gap-[30px] xl:gap-[60px]' : 'hidden'}>
         <CompareButton />
         <ProfileDropdown session={session} />
       </div>

--- a/src/components/common/gnb/section/DesktopRight.tsx
+++ b/src/components/common/gnb/section/DesktopRight.tsx
@@ -5,7 +5,14 @@ import LoginButton from '../buttons/LoginButton';
 import SignupButton from '../buttons/SignupButton';
 import ProfileDropdown from '../profile/ProfileDropdown';
 
-const DesktopRight = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
+import type { Session } from 'next-auth';
+
+interface DesktopRightProps {
+  session: Session | null;
+}
+
+const DesktopRight = ({ session }: DesktopRightProps) => {
+  const isLoggedIn = !!session;
   return (
     <div>
       {/* guest */}
@@ -16,7 +23,7 @@ const DesktopRight = ({ isLoggedIn }: { isLoggedIn: boolean }) => {
       {/* auth */}
       <div className={isLoggedIn ? 'flex gap-5' : 'hidden'}>
         <CompareButton />
-        <ProfileDropdown /> {/* 프로필 너비를 고정할 거라면 hidden 안써도 될듯 */}
+        <ProfileDropdown session={session} />
       </div>
     </div>
   );

--- a/src/components/common/gnb/section/DesktopRight.tsx
+++ b/src/components/common/gnb/section/DesktopRight.tsx
@@ -1,17 +1,14 @@
 'use client';
 
+import { useSession } from 'next-auth/react';
+
 import CompareButton from '../buttons/CompareButton';
 import LoginButton from '../buttons/LoginButton';
 import SignupButton from '../buttons/SignupButton';
 import ProfileDropdown from '../profile/ProfileDropdown';
 
-import type { Session } from 'next-auth';
-
-interface DesktopRightProps {
-  session: Session | null;
-}
-
-const DesktopRight = ({ session }: DesktopRightProps) => {
+const DesktopRight = () => {
+  const { data: session } = useSession();
   const isLoggedIn = !!session;
   return (
     <div>

--- a/src/components/common/gnb/section/MobileLeft.tsx
+++ b/src/components/common/gnb/section/MobileLeft.tsx
@@ -1,13 +1,7 @@
 import MobileMenu from '../mobileMenu/MobileMenu';
 
-import type { Session } from 'next-auth';
-
-interface MobileLeftProps {
-  session: Session | null;
-}
-
-const MobileLeft = ({ session }: MobileLeftProps) => {
-  return <MobileMenu session={session} />;
+const MobileLeft = () => {
+  return <MobileMenu />;
 };
 
 export default MobileLeft;

--- a/src/store/compareStore.ts
+++ b/src/store/compareStore.ts
@@ -1,0 +1,66 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import { Product } from '@/types/product/productType';
+
+interface CompareState {
+  compareList: Product[];
+  addProduct: (product: Product) => { removedProduct?: Product };
+  removeProduct: (productId: number) => void;
+  clearCompareList: () => void;
+  isProductInList: (productId: number) => boolean;
+  undoRemove: (removedProduct: Product, newProduct: Product) => void;
+}
+
+export const useCompareStore = create<CompareState>()(
+  persist(
+    (set, get) => ({
+      compareList: [],
+
+      addProduct: (product: Product) => {
+        const { compareList } = get();
+
+        // 이미 있는 상품인지 확인
+        if (compareList.some((p) => p.id === product.id)) {
+          return {};
+        }
+
+        let newList = [...compareList, product];
+        let removedProduct: Product | undefined;
+
+        // 최대 4개 제한, FIFO(가장 앞의 상품부터 제거) 방식
+        if (newList.length > 4) {
+          removedProduct = newList[0];
+          newList = newList.slice(1);
+        }
+
+        set({ compareList: newList });
+        return { removedProduct };
+      },
+
+      removeProduct: (productId: number) => {
+        set((state) => ({
+          compareList: state.compareList.filter((p) => p.id !== productId),
+        }));
+      },
+
+      clearCompareList: () => {
+        set({ compareList: [] });
+      },
+
+      isProductInList: (productId: number) => {
+        return get().compareList.some((p) => p.id === productId);
+      },
+
+      undoRemove: (removedProduct: Product, newProduct: Product) => {
+        const { compareList } = get();
+        // 새로 추가된 상품 제거하고 삭제된 상품을 맨 앞에 복원
+        const listWithoutNew = compareList.filter((p) => p.id !== newProduct.id);
+        set({ compareList: [removedProduct, ...listWithoutNew] });
+      },
+    }),
+    {
+      name: 'compare-storage',
+    },
+  ),
+);


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/project-part4-team3/issue/LIN-47/랜딩페이지-1차-qa-반영

## 💡 변경 사항 요약

1차 QA 수정사항 반영

### 📌 세부 변경 내용

- 랜딩 페이지 속도 향상
- 추천목록 키보드 접근성 추가
- 모바일 카테고리 필터 위치 변경
- gnb 내 버튼 css 속성 추가
- 추천 목록 내 카테고리 칩 공용칩으로 변경
- gnb 로그인 상태 연결
- 헤더 클라이언트 컴포로 변경 및 프롭 구조로 변경
- 프로필 드롭다운 내 로그인/회원가입 값 삭제
- 모바일 햄버거버튼 애니메이션 추가

### 🧪 테스트 방법 및 결과 (선택 사항)

1.
2.

### 📸 스크린샷 (선택 사항)

**1) 추천목록 변경점**

<img width="916" height="404" alt="image" src="https://github.com/user-attachments/assets/50409b2a-c892-4759-9d48-313e89dd7163" />

- 내부 카테고리칩을 공용 컴포넌트로 수정하였습니다.
- 키보드 접근성을 추가하였으며, 마우스와 키보드 상태를 연동하여 입력장치를 두가지 쓰더라도 한가지 값만 반영하게 하였습니다.

**2) 헤더 변경점**
<img width="3800" height="192" alt="image" src="https://github.com/user-attachments/assets/1e0cc2fb-46ea-4c8d-8ac7-2f331546b4e4" />
<img width="3826" height="380" alt="image" src="https://github.com/user-attachments/assets/a999c031-34fe-4a11-baee-d2c7a63bae53" />

- 일관적인 로그인 상태 관리를 위해 헤더를 클라이언트 컴포넌트로 변경하였습니다.
- 헤더에 로그인 상태 업데이트를 위해 signin 페이지 내 nextsession 업데이트 로직을 추가하였습니다.
- 유지보수성을 높이기 위해 프롭 구조로 변경하였습니다.
- 각 버튼 간 간격과 글꼴 등 css를 추가했습니다.
- 사용자 닉네임이 길어질 경우 축약되며, 호버 시 전체 닉네임이 타이틀박스로 보여집니다.
- 로그인X : 프로필 드롭다운 내 로그인/회원가입 값을 다시 삭제하였습니다.
- 프로필 드롭다운 내 글씨크기 및 프로필 사진 사이즈를 조정하였습니다.
- 모바일 헤더 내 햄버거버튼을 닫을 때 애니메이션이 추가되었습니다.


**3) 리뷰어 랭킹 변경점**
<img width="498" height="968" alt="image" src="https://github.com/user-attachments/assets/018d28c6-95f8-4df7-8a9a-eee752feb60f" />

- 리뷰어 닉네임이 길어질 경우 축약되며, 호버 시 전체 닉네임이 타이틀박스로 보여집니다.

**4) 모바일 카테고리 변경점**
<img width="864" height="876" alt="image" src="https://github.com/user-attachments/assets/280b63d9-849f-4fbd-944a-46cfd43e27a0" />
<img width="874" height="808" alt="image" src="https://github.com/user-attachments/assets/335c2cab-7aaf-4e2c-8b20-a51737aee0aa" />

- 기존에 카테고리 선택 시 이동하던 카테고리 버튼의 위치를 고정하였습니다.
- sort 버튼은 검색 결과 타이틀과 같은 선상으로 위치 수정하였습니다.

**5) 전체 페이지 변경점**
<img width="3830" height="1942" alt="image" src="https://github.com/user-attachments/assets/08fdfe44-1233-4693-99f2-2ace8b7df46b" />

- 페이지 내 전반적인 여백을 수정하였습니다. 카드 크기 고정 시 추가 조정 예정입니다.
- api 호출을 promise.all로 통합하여 랜딩페이지 로딩 속도를 개선했습니다.


### ✍️ 추가 코멘트 (선택 사항)

- 검색인풋창에 고정값을 주지 않고 flex로 간격 조정을 다시 해봤는데 이번에는 어떻게 보일지 잘 모르겠습니다. 이전처럼 사용자 화면에 따라 크기가 다르게 보인다면 픽스값 부여해서 수정하겠습니다.
