### PR TITLE
Feat/lin 58 비교하기 zustand 상태 및 모달, 토스트 생성

### DIFF
--- a/src/app/compare/components/CompareConfirmModal.tsx
+++ b/src/app/compare/components/CompareConfirmModal.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import Modal from '@/components/common/ModalUi';
 import Button from '@/components/ui/Buttons';
 import { useModalStore } from '@/store/modalStore';
 
@@ -19,7 +20,7 @@ const CompareConfirmModal = () => {
   };
 
   return (
-    <div>
+    <Modal variant='compare'>
       <h2>비교하기</h2>
       <p>비교하러 가시겠습니까?</p>
       <div className='flex gap-3'>
@@ -30,7 +31,7 @@ const CompareConfirmModal = () => {
           비교하러 가기
         </Button>
       </div>
-    </div>
+    </Modal>
   );
 };
 

--- a/src/app/products/[productId]/components/AddToCompareButton.tsx
+++ b/src/app/products/[productId]/components/AddToCompareButton.tsx
@@ -42,10 +42,15 @@ const AddToCompareButton = ({ product, className }: AddToCompareButtonProps) => 
               label: 'Undo',
               onClick: () => undoRemove(result.removedProduct!, product),
             },
-            style: {
-              '--action-button-color': '#3b82f6',
-              '--action-button-color-hover': '#2563eb',
-            } as React.CSSProperties,
+            actionButtonStyle: {
+              backgroundColor: '#3b82f6',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              padding: '4px 8px',
+              fontSize: '12px',
+              fontWeight: '500',
+            },
           },
         );
       }

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -4,6 +4,7 @@ import { getProductDetail } from '@/actions/productDetail';
 import { getProductReviews } from '@/actions/review/review';
 import CategoryChip from '@/components/ui/chips/CategoryChip';
 
+import AddToCompareButton from './components/AddToCompareButton';
 import FavoriteButton from './components/FavoriteButton';
 import MetricCard from './components/MetricCard';
 import ProductTriggers from './components/ProductTriggers';

--- a/src/app/products/[productId]/page.tsx
+++ b/src/app/products/[productId]/page.tsx
@@ -4,7 +4,6 @@ import { getProductDetail } from '@/actions/productDetail';
 import { getProductReviews } from '@/actions/review/review';
 import CategoryChip from '@/components/ui/chips/CategoryChip';
 
-import AddToCompareButton from './components/AddToCompareButton';
 import FavoriteButton from './components/FavoriteButton';
 import MetricCard from './components/MetricCard';
 import ProductTriggers from './components/ProductTriggers';


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/project-part4-team3/issue/LIN-58/비교하기-비교하기-버튼-및-상태-작업

## 💡 변경 사항 요약

비교하기 버튼을 눌러 상품을 담고, 상태에 따라 토스트, 모달을 출력합니다.

### 📌 세부 변경 내용

- zustand에 최대 4개까지 목록을 생성합니다. 
- 브라우저를 닫더라도 해당 목록이 저장됩니다.
- 담긴 상품이 1개일 때 비교 대상 추가 토스트
- 담긴 상품이 2개 이상일 때 비교하러가기 모달
- 담긴 상품이 4개 이상일 때 가장 오래된 것부터 삭제된다는 토스트 -> undo도 가능
- 이미 담긴 상품을 다시 담으려 할때 이미 담긴 상품이라는 토스트

### 🧪 테스트 방법 및 결과 (선택 사항)

1.
2.

### 📸 스크린샷 (선택 사항)

**1) 담긴 상품이 1개일 때**
<img width="836" height="212" alt="image" src="https://github.com/user-attachments/assets/f6968c28-9410-4794-85d7-7cc3d9ef2c6c" />

**2) 담긴 상품이 2개 이상일 때**
<img width="1248" height="610" alt="image" src="https://github.com/user-attachments/assets/31e6a939-1000-41d7-b993-a980a0be33d2" />
- 아직 모달 내 css 적용 전입니다

**3) 담긴 상품이 4개 이상일 때**
<img width="876" height="240" alt="image" src="https://github.com/user-attachments/assets/6385667a-1533-4f4c-ba4d-06aab02e8f26" />
- 가장 예전에 담긴 상품을 먼저 제거하고 추가합니다.
- undo를 누르면 현재 상품 담기와 예전 상품 제거를 취소합니다.

**4) 중복된 상품을 담으려 할 때**
<img width="864" height="208" alt="image" src="https://github.com/user-attachments/assets/0e32fd84-3020-434c-a871-9b7f709abfcd" />

### ✍️ 추가 코멘트 (선택 사항)

- 아직 css 적용 전입니다. 토스트 글씨 크기나, 문구의 길이 등에서 가독성을 높일 수 있는 방법을 추가 고민해야할 것 같습니다.
