### PR TITLE
feat/lin 67 비교하기 버튼 내 카운팅 추가

### DIFF
--- a/src/components/common/gnb/buttons/CompareButton.tsx
+++ b/src/components/common/gnb/buttons/CompareButton.tsx
@@ -1,12 +1,33 @@
+'use client';
+
 import Link from 'next/link';
 
+import { useCompareStore } from '@/store/compareStore';
+
 const CompareButton = () => {
+  const { compareList } = useCompareStore();
+  const count = compareList.length;
+
   return (
+    // 버튼 내 숫자 버전
+    // <Link
+    //   href='/compare'
+    //   className='md:text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5 whitespace-nowrap'
+    // >
+    //   비교하기 {count > 0 && `(${count})`}
+    // </Link>
+
+    // 버튼 위 숫자 버전
     <Link
       href='/compare'
-      className='md:text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5 whitespace-nowrap'
+      className='md:text-mogazoa-14px-400 xl:text-mogazoa-16px-400 text-white-f1f1f5 relative whitespace-nowrap'
     >
       비교하기
+      {count > 0 && (
+        <span className='bg-main-gradation text-white-f1f1f5 text-mogazoa-10px-300 xl:text-mogazoa-12px-300 absolute -top-2.5 -right-3.5 flex h-3 w-3 items-center justify-center rounded-full xl:h-4 xl:w-4'>
+          {count}
+        </span>
+      )}
     </Link>
   );
 };

--- a/src/components/common/gnb/mobileMenu/MobileMenuList.tsx
+++ b/src/components/common/gnb/mobileMenu/MobileMenuList.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { signOut } from 'next-auth/react';
 
+import { useCompareStore } from '@/store/compareStore';
+
 import AvatarProfile from '../profile/AvatarProfile';
 
 const MobileMenuList = ({
@@ -16,6 +18,9 @@ const MobileMenuList = ({
   profileUrl?: string | null;
   onClose: () => void;
 }) => {
+  const { compareList } = useCompareStore();
+  const count = compareList.length;
+
   return (
     <div className='flex h-full flex-col'>
       {/* guest */}
@@ -54,13 +59,20 @@ const MobileMenuList = ({
         <div className='flex-1 pt-5'>
           <h2 className='text-white-f1f1f5 text-mogazoa-20px-600 mb-6'>메뉴</h2>
           <ul className='pt-3'>
-            <li>
+            <li className='flex gap-2'>
               <Link
                 href='/compare'
                 onClick={onClose}
                 className='hover:bg-black-353542 text-white-f1f1f5 text-mogazoa-18px-400 block rounded-lg px-4 py-3 transition-colors'
               >
-                비교하기
+                <span className='flex items-center gap-2'>
+                  비교하기
+                  {count > 0 && (
+                    <span className='bg-main-gradation text-white-f1f1f5 text-mogazoa-12px-300 flex h-4 w-4 min-w-4 items-center justify-center rounded-full'>
+                      {count}
+                    </span>
+                  )}
+                </span>
               </Link>
             </li>
             <li>


### PR DESCRIPTION
### 🚨 PR 제목 컨벤션 (필수)

- `feat: 새로운 기능 추가`
- `fix: 버그 수정`
- `docs: 문서 변경`
- `chore: 기타 작업`
- `허용된 타입 목록: feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert`
- Linear Issue Key 를 포함해주세요. 예: `LIN-123/feat: 새로운 기능 추가`

## 🪓 관련 Linear Issue

Linear 이슈 링크: https://linear.app/project-part4-team3/issue/LIN-67/비교하기-버튼-내-목록-카운팅

## 💡 변경 사항 요약

버튼 내 카운팅 추가

### 📌 세부 변경 내용

- 비교하기 목록의 길이가 0 초과일 경우 비교하기 목록 개수가 버튼 내 출력됩니다.

### 🧪 테스트 방법 및 결과 (선택 사항)

1.
2.

### 📸 스크린샷 (선택 사항)

**0) 비교하기 목록이 없을 때**
<img width="3518" height="172" alt="image" src="https://github.com/user-attachments/assets/7cb1447d-650b-4638-a75e-ea78e627f9b6" />

**1) 버튼 내 숫자 버전**
<img width="3436" height="198" alt="image" src="https://github.com/user-attachments/assets/09121653-72e5-4368-be61-7dd2ee8e8f27" />

**2) 라운드 버전**
<img width="3438" height="200" alt="image" src="https://github.com/user-attachments/assets/cd2efcbb-7efa-4c9c-978b-88b1fa2e1afd" />

**3) 모바일 사이드바 내 라운드 버전**
<img width="630" height="792" alt="image" src="https://github.com/user-attachments/assets/739be771-9942-4809-8d5e-0c42f8bc00d3" />


### ✍️ 추가 코멘트 (선택 사항)

- 개인적으로 라운드버전이 더 좋은 것 같습니다.
- 다만 가독성을 고려할 때 라운드 버전에서 숫자를 더 키우면 좀 어색할 것 같기도 합니다. 데스크톱에서도 모바일처럼 버튼 오른쪽에 크게 넣는 방향도 괜찮을 것 같습니다
